### PR TITLE
[EPO-2794] GalaxiesSelector selections synchronized with GalacticProperties plot

### DIFF
--- a/src/components/charts/galacticProperties/Point.jsx
+++ b/src/components/charts/galacticProperties/Point.jsx
@@ -9,7 +9,6 @@ class Point extends React.PureComponent {
     super(props);
 
     this.baseRadius = 6;
-    this.baseDiameter = this.baseRadius * 2;
     this.svgEl = React.createRef();
   }
 
@@ -22,7 +21,7 @@ class Point extends React.PureComponent {
         .transition()
         .duration(800)
         .ease(d3EaseElastic)
-        .attr('r', this.baseDiameter);
+        .attr('r', this.baseRadius * 2);
     } else {
       $point
         .transition()

--- a/src/components/charts/galacticProperties/Points.jsx
+++ b/src/components/charts/galacticProperties/Points.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import includes from 'lodash/includes';
+import find from 'lodash/find';
 import classnames from 'classnames';
 import Point from './Point.jsx';
 import { invisible } from './galactic-properties.module.scss';
@@ -27,8 +27,8 @@ class Points extends React.PureComponent {
           const plottingColor = yValueAccessor === 'color';
           const x = d[xValueAccessor];
           const y = d[yValueAccessor];
-          const selected = includes(selectedData, d);
-          const hovered = includes(hoveredData, d);
+          const selected = !!find(selectedData, { id });
+          const hovered = !!find(hoveredData, { id });
           const classes = classnames(`data-point-${name || id}`, 'data-point', {
             [pointClasses]: pointClasses,
             selected,

--- a/src/components/charts/galaxySelector/Point.jsx
+++ b/src/components/charts/galaxySelector/Point.jsx
@@ -1,9 +1,36 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { select as d3Select } from 'd3-selection';
+import { easeElastic as d3EaseElastic } from 'd3-ease';
 import { galaxy, selected } from './galaxy-selector.module.scss';
 
 class Point extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.svgEl = React.createRef();
+  }
+
+  componentDidUpdate() {
+    const { isActive, id } = this.props;
+    const $point = d3Select(this.svgEl.current);
+    const baseRadius = this.getRadius(id);
+
+    if (isActive) {
+      $point
+        .transition()
+        .duration(800)
+        .ease(d3EaseElastic)
+        .attr('r', baseRadius * 2);
+    } else {
+      $point
+        .transition()
+        .duration(400)
+        .attr('r', baseRadius);
+    }
+  }
+
   getRadius(id) {
     return (
       {
@@ -13,8 +40,20 @@ class Point extends React.PureComponent {
     );
   }
 
+  getStroke(isActive, isSelected, color) {
+    if (isActive) {
+      return '#fed828';
+    }
+
+    if (isSelected) {
+      return color;
+    }
+
+    return 'transparent';
+  }
+
   render() {
-    const { selected: isSelected, x, y, color, classes, id } = this.props;
+    const { isActive, isSelected, x, y, color, classes, id } = this.props;
     const pointClasses = classnames(
       galaxy,
       'data-point',
@@ -27,12 +66,13 @@ class Point extends React.PureComponent {
 
     return (
       <circle
+        ref={this.svgEl}
         className={pointClasses}
         cx={x}
         cy={y}
         r={this.getRadius(id)}
         fill="transparent"
-        stroke={!isSelected ? 'transparent' : color}
+        stroke={this.getStroke(isActive, isSelected, color)}
         strokeWidth={0}
       />
     );
@@ -41,7 +81,8 @@ class Point extends React.PureComponent {
 
 Point.propTypes = {
   id: PropTypes.string,
-  selected: PropTypes.bool,
+  isSelected: PropTypes.bool,
+  isActive: PropTypes.bool,
   x: PropTypes.number,
   y: PropTypes.number,
   classes: PropTypes.string,

--- a/src/components/charts/galaxySelector/Points.jsx
+++ b/src/components/charts/galaxySelector/Points.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import find from 'lodash/find';
 import isNumber from 'lodash/isNumber';
-import { isSelected } from './galaxySelectorUtilities.js';
 import Point from './Point.jsx';
 
 class Points extends React.PureComponent {
@@ -14,23 +14,24 @@ class Points extends React.PureComponent {
       xValueAccessor,
       yValueAccessor,
       pointClasses,
+      active,
     } = this.props;
 
     return (
       <g className={`data-points ${pointClasses}`}>
         {data.map(d => {
           const { id, color } = d;
-          const selected = isSelected(selectedData, d);
+          const isSelected = !!find(selectedData, { id: d.id });
+          const isActive = active ? active.id === d.id : false;
 
           return (
             <Point
               key={`point-${id}`}
-              id={id}
+              {...{ id, isSelected, isActive }}
               classes={pointClasses}
               x={xScale(d[xValueAccessor])}
               y={yScale(d[yValueAccessor])}
               color={isNumber(color) ? '#c82960' : color}
-              selected={selected}
               tabIndex="0"
             />
           );
@@ -43,6 +44,7 @@ class Points extends React.PureComponent {
 Points.propTypes = {
   data: PropTypes.array,
   selectedData: PropTypes.array,
+  active: PropTypes.object,
   xValueAccessor: PropTypes.string,
   yValueAccessor: PropTypes.string,
   xScale: PropTypes.func,

--- a/src/components/charts/galaxySelector/galaxy-selector.module.scss
+++ b/src/components/charts/galaxySelector/galaxy-selector.module.scss
@@ -6,7 +6,6 @@
 
 .galaxy {
   @include dataPoint;
-  fill: transparent;
   transition: fill $timing $duration;
 
   &.selected {

--- a/src/components/charts/galaxySelector/galaxySelectorUtilities.js
+++ b/src/components/charts/galaxySelector/galaxySelectorUtilities.js
@@ -8,20 +8,6 @@ export const getActiveIndex = (images, activeId) => {
   });
 };
 
-export const isSelected = (data, datum) => {
-  let selected = false;
-
-  if (!data) return selected;
-
-  data.forEach(item => {
-    if (datum.id === item.id) {
-      selected = true;
-    }
-  });
-
-  return selected;
-};
-
 export const getActiveImageIndex = (
   activeGalaxy,
   activeAlert,

--- a/src/components/charts/galaxySelector/legend/LegendBox.jsx
+++ b/src/components/charts/galaxySelector/legend/LegendBox.jsx
@@ -1,22 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import find from 'lodash/find';
 import StellarValue from '../../shared/StellarValue';
 import { legendBox, detail, output } from './legend.module.scss';
 
 class LegendBox extends React.PureComponent {
-  isSelected(id, data) {
-    let selected = false;
-    if (!data) return selected;
-
-    data.forEach(datum => {
-      if (datum.id === id) {
-        selected = true;
-      }
-    });
-
-    return selected;
-  }
-
   render() {
     const { id, selectedData, label, valueAccessor, value } = this.props;
 
@@ -24,7 +12,7 @@ class LegendBox extends React.PureComponent {
       <div className={legendBox}>
         <div className={detail}>{label}</div>
         <div className={`${detail} ${output}`}>
-          {this.isSelected(id, selectedData) ? (
+          {find(selectedData, { id }) ? (
             <StellarValue type={valueAccessor} value={value} />
           ) : (
             <span>&nbsp;</span>

--- a/src/containers/GalaxySelectorContainer.jsx
+++ b/src/containers/GalaxySelectorContainer.jsx
@@ -168,6 +168,8 @@ class GalaxySelectorContainer extends React.PureComponent {
   }
 
   selectionCallback = d => {
+    if (!d) return;
+
     const {
       answers,
       updateAnswer,
@@ -175,13 +177,13 @@ class GalaxySelectorContainer extends React.PureComponent {
       options: { toggleDataPointsVisibility },
     } = this.props;
     const { activeGalaxy } = this.state;
-
     const qId = toggleDataPointsVisibility || activeQuestionId;
-    const dObj = { [activeGalaxy.name]: d };
-    const answer = answers[qId];
-    const answerObj = !isEmpty(answer) ? { ...answer.data, ...dObj } : dObj;
 
     if (qId) {
+      const dObj = { [activeGalaxy.name]: d };
+      const answer = answers[qId];
+      const answerObj = !isEmpty(answer) ? { ...answer.data, ...dObj } : dObj;
+
       updateAnswer(qId, answerObj);
     }
 

--- a/src/containers/SupernovaSelectorWithLightCurveContainer.jsx
+++ b/src/containers/SupernovaSelectorWithLightCurveContainer.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { graphql, StaticQuery } from 'gatsby';
 import classnames from 'classnames';
 import isEmpty from 'lodash/isEmpty';
-// import { min as d3Min, max as d3Max, extent as d3Extent } from 'd3-array';
 import API from '../lib/API.js';
 import {
   getSelectedData,
@@ -81,6 +80,8 @@ class SupernovaSelectorWithLightCurveContainer extends React.PureComponent {
   };
 
   supernovaSelectionCallback = d => {
+    if (!d) return;
+
     const {
       answers,
       updateAnswer,
@@ -88,13 +89,13 @@ class SupernovaSelectorWithLightCurveContainer extends React.PureComponent {
       options: { toggleDataPointsVisibility },
     } = this.props;
     const { activeGalaxy } = this.state;
-
     const qId = toggleDataPointsVisibility || activeQuestionId;
-    const dObj = { [activeGalaxy.name]: d };
-    const answer = answers[qId];
-    const answerObj = !isEmpty(answer) ? { ...answer.data, ...dObj } : dObj;
 
     if (qId) {
+      const dObj = { [activeGalaxy.name]: d };
+      const answer = answers[qId];
+      const answerObj = !isEmpty(answer) ? { ...answer.data, ...dObj } : dObj;
+
       updateAnswer(qId, answerObj);
     }
 
@@ -214,7 +215,8 @@ class SupernovaSelectorWithLightCurveContainer extends React.PureComponent {
             >
               <SupernovaSelector
                 className={`supernova-selector-${name}`}
-                {...{ selectedData, activeGalaxy, autoplay, preSelected }}
+                autoplay={autoplay && !selectedData}
+                {...{ selectedData, activeGalaxy, preSelected }}
                 data={getSupernovaPointData(activeGalaxy)}
                 alerts={activeGalaxy ? activeGalaxy.alerts : []}
                 images={activeGalaxy ? activeGalaxy.images : []}

--- a/src/data/pages/effects-of-expansion.json
+++ b/src/data/pages/effects-of-expansion.json
@@ -6,7 +6,7 @@
   "slug": "effects-of-expansion/",
   "previous": {
     "title": "Exploring the Deep",
-    "link": "/exploring-the-deep/"
+    "link": "/exploring-the-deep-1/"
   },
   "next": {
     "title": "Exploring the Relationship between Color & Distance",

--- a/src/data/pages/exploring-lsst-data-2.json
+++ b/src/data/pages/exploring-lsst-data-2.json
@@ -31,7 +31,7 @@
         "tooltipAccessors": ["distance", "brightness"],
         "tooltipUnits": ["Billion Ly"],
         "tooltipLabels": ["Distance", "Brightness"],
-        "domain": [[0, 28], [0, 100]]
+        "domain": [[0, 28], [0, 200]]
       }
     }
   ],


### PR DESCRIPTION
As selections are made in GalaxiesSelector both it and corresponding plot "highlight" active selection;
Any time an existing selection is clicked in either the selector or plot it becomes active in both the selector and the plot and therefore "highlighted";
Includes updates to other components using GalaxySelector to accept null selections;