### PR TITLE
[B] Fix globalState race condition in randomData

### DIFF
--- a/src/containers/GalaxiesSelectorContainer.jsx
+++ b/src/containers/GalaxiesSelectorContainer.jsx
@@ -15,22 +15,23 @@ class GalaxiesSelectorContainer extends React.PureComponent {
     this.state = {
       data: null,
       name: null,
+      sourcePath: null,
       imagePath: null,
       domain: [],
       activeGalaxy: null,
     };
+
+    this.aId = 'randomGalaxies';
   }
 
   componentDidMount() {
     const {
       widget: { source, sources },
       options,
-      updateAnswer,
       answers,
     } = this.props;
     const { randomSource } = options || {};
-    const aId = 'randomGalaxies';
-    const randomGalaxiesAnswer = answers[aId];
+    const randomGalaxiesAnswer = answers[this.aId];
 
     if (source) {
       this.getSetData(source);
@@ -43,7 +44,19 @@ class GalaxiesSelectorContainer extends React.PureComponent {
         sources[randomIntFromInterval(0, sources.length - 1)];
 
       this.getSetData(randomSourcePath);
-      updateAnswer(aId, randomSourcePath);
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const { updateAnswer, options, answers } = this.props;
+    const { randomSource } = options || {};
+
+    const { sourcePath } = this.state;
+    const newSource = prevState.sourcePath !== sourcePath && !!sourcePath;
+    const randomGalaxiesAnswer = answers[this.aId];
+
+    if (newSource && randomSource && !randomGalaxiesAnswer) {
+      updateAnswer(this.aId, sourcePath);
     }
   }
 
@@ -57,6 +70,7 @@ class GalaxiesSelectorContainer extends React.PureComponent {
       this.setState(prevState => ({
         ...prevState,
         data: objects,
+        sourcePath: source,
         imagePath: `/images/galaxies/hsc/${name}.jpg`,
         name,
         domain: [ra.reverse(), dec],

--- a/src/state/GlobalStore.js
+++ b/src/state/GlobalStore.js
@@ -125,17 +125,7 @@ class GlobalStore {
       (global, dispatch, pageId, qId, answered) => {
         const { investigationProgress: prevIPS } = global;
         const prevPageIPS = prevIPS[pageId];
-
-        if (!prevIPS[pageId]) {
-          return global;
-        }
-
         const { questions, answers: prevAnswers } = prevPageIPS;
-
-        if (!questions[qId]) {
-          return global;
-        }
-
         const indexOfprevAnswered = prevAnswers.indexOf(qId);
         const prevAnswered = indexOfprevAnswered >= 0;
         const answers = [...prevAnswers];


### PR DESCRIPTION
Previously, when random data option was true GalaxiesSelector fetched random data and then immediately created an answer in order to persist the data across pages.  That was causing a race condition between the fetch and GlobalState updating when visiting the page for the first
with nothing previously saved in localStorage.  This update punts the answer creation to DidUpdate avoiding since the answer creation is not vital until after you click through to a different page.  This avoids the race altogether