### PR TITLE
[EPO-2891] GalaxySelectorHubblePlot advances to next unselected galaxy

### DIFF
--- a/src/components/charts/galaxySelector/blinker/BlinkerImage.jsx
+++ b/src/components/charts/galaxySelector/blinker/BlinkerImage.jsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import {
-  activeImage,
-  blinkImageContainer,
-  blinkerImage,
-} from './blinker.module.scss';
+import { activeImage, blinkerImage } from './blinker.module.scss';
 
 const BlinkerImage = ({ image, active, alertId }) => {
   const imageClasses = classnames(blinkerImage, {
@@ -13,13 +9,11 @@ const BlinkerImage = ({ image, active, alertId }) => {
   });
 
   return (
-    <div className={blinkImageContainer}>
-      <img
-        className={imageClasses}
-        alt={`Cutout for alert ${alertId}`}
-        src={image}
-      />
-    </div>
+    <img
+      className={imageClasses}
+      alt={`Cutout for alert ${alertId}`}
+      src={image}
+    />
   );
 };
 

--- a/src/components/charts/galaxySelector/blinker/blinker.module.scss
+++ b/src/components/charts/galaxySelector/blinker/blinker.module.scss
@@ -1,5 +1,4 @@
-.blink-container,
-.blink-image-container {
+.blink-container {
   position: absolute;
   top: 0;
   right: 0;
@@ -8,6 +7,11 @@
 }
 
 .blinker-image {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   width: 100%;
   height: 100%;
   opacity: 0;

--- a/src/components/charts/galaxySelector/index.jsx
+++ b/src/components/charts/galaxySelector/index.jsx
@@ -52,29 +52,28 @@ class GalaxySelector extends React.PureComponent {
     }
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     const {
       activeGalaxy,
       data,
       selectedData,
       preSelected,
-      autoplay,
       xDomain,
       yDomain,
     } = this.props;
+    const { playing } = this.state;
+    const isNewData = prevProps.data !== data;
+    const isNewActiveGalaxy = prevProps.activeGalaxy !== activeGalaxy;
+    const isNewSelectedData = prevProps.selectedData !== selectedData;
 
-    const { selectedData: prevSelectedData } = prevProps;
-    const { playing } = prevState;
-
-    if (
-      prevProps.activeGalaxy !== activeGalaxy ||
-      prevSelectedData !== selectedData
-    ) {
+    if (isNewData || isNewActiveGalaxy || isNewSelectedData) {
       this.updatePoints();
       this.setSelection(preSelected ? data : selectedData);
 
-      if (autoplay && !playing && !selectedData) {
-        this.startBlink();
+      if (!playing) {
+        this.stopBlink();
+      } else if (playing) {
+        this.restartBlink();
       }
     }
 
@@ -160,6 +159,23 @@ class GalaxySelector extends React.PureComponent {
     const activeImageId = images[activeImageIndex].id;
     const activeAlert = getAlertFromImageId(activeImageId, alerts);
     return { activeImageId, activeImageIndex, activeAlert };
+  }
+
+  restartBlink() {
+    clearInterval(this.blinkerInterval);
+    const { images } = this.props;
+
+    this.setState(
+      prevState => ({
+        ...prevState,
+        playing: true,
+      }),
+      () => {
+        this.blinkerInterval = setInterval(() => {
+          this.nextBlink(images);
+        }, 200);
+      }
+    );
   }
 
   startBlink() {

--- a/src/components/charts/lightCurve/index.jsx
+++ b/src/components/charts/lightCurve/index.jsx
@@ -100,7 +100,6 @@ class LightCurve extends React.PureComponent {
       });
     } else {
       const domain = d3Extent(data, d => d[accessor]);
-      console.log(domain);
       min = domain[0];
       max = domain[1];
     }

--- a/src/containers/GalaxySelectorContainer.jsx
+++ b/src/containers/GalaxySelectorContainer.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import React from 'react';
 import PropTypes from 'prop-types';
 import isEmpty from 'lodash/isEmpty';
@@ -26,14 +25,14 @@ class GalaxySelectorContainer extends React.PureComponent {
     super(props);
 
     this.state = {
-      openScatterPlot: false,
-      openMenu: false,
-      activeImageIndex: 0,
-      activeGalaxy: null,
+      data: null,
       plottedData: null,
-      activeAlertId: null,
+      openScatterPlot: false,
+      activeGalaxy: null,
       activeAlert: null,
-      data: [],
+      activeImageIndex: 0,
+      activeImageId: null,
+      openMenu: false,
     };
   }
 
@@ -54,7 +53,6 @@ class GalaxySelectorContainer extends React.PureComponent {
 
       this.setState(prevState => ({
         ...prevState,
-        activeAlertId: alerts[0].alert_id,
         activeAlert: alerts[0],
         activeGalaxy: data[0],
         data,
@@ -66,15 +64,16 @@ class GalaxySelectorContainer extends React.PureComponent {
   chooseGalaxyAndClosePlot(event, activeGalaxy) {
     if (event) {
       const { openScatterPlot } = this.state;
-      const { alerts } = activeGalaxy;
-
       if (openScatterPlot) this.handleSlideOutPlot('close');
+
+      const { alerts } = activeGalaxy;
+      const activeAlert = alerts[0];
 
       this.setState(prevState => ({
         ...prevState,
         activeGalaxy,
         activeImageIndex: 0,
-        activeAlertId: alerts[0].alert_id,
+        activeImageId: activeAlert.image_id,
         activeAlert: alerts[0],
       }));
     }
@@ -119,13 +118,14 @@ class GalaxySelectorContainer extends React.PureComponent {
     }
 
     const { alerts } = activeGalaxy;
+    const activeAlert = alerts[0];
 
     this.setState(prevState => ({
       ...prevState,
       activeGalaxy,
       activeImageIndex: 0,
-      activeAlertId: alerts[0].alert_id,
-      activeAlert: alerts[0],
+      activeImageId: activeAlert.image_id,
+      activeAlert,
     }));
   }
 
@@ -224,7 +224,7 @@ class GalaxySelectorContainer extends React.PureComponent {
     const {
       answers,
       options,
-      options: { toggleDataPointsVisibility, image },
+      options: { toggleDataPointsVisibility, image, autoplay },
     } = this.props;
 
     const selectedData = getSelectedData(
@@ -236,58 +236,62 @@ class GalaxySelectorContainer extends React.PureComponent {
     return (
       <>
         <h2 className="space-bottom heading-primary">Galaxy Selector</h2>
-        <NavDrawer
-          showNavDrawer
-          interactableToolbar
-          classes={styles.galaxyNavDrawer}
-          cardClasses={styles.container}
-          contentClasses={styles.galaxyDrawerContent}
-          drawerClasses={styles.galaxyDrawer}
-          navItems={this.generateNavItems(data)}
-          toolbarStyles={
-            activeGalaxy ? { backgroundColor: activeGalaxy.color } : null
-          }
-          toolbarTitle={activeGalaxy ? activeGalaxy.name : 'Galaxy Selector'}
-          toolbarActions={<Legend {...{ activeGalaxy, selectedData }} />}
-          menuOpenCallback={this.closeScatterPlot}
-        >
-          <div className="galaxy-selector-images--container">
-            <GalaxySelector
-              className={`galaxy-selector-${data.name}`}
-              {...{ selectedData, activeGalaxy }}
-              data={getGalaxyPointData(activeGalaxy)}
-              alerts={activeGalaxy ? activeGalaxy.alerts : []}
-              image={image}
-              images={activeGalaxy ? activeGalaxy.images : []}
-              selectionCallback={this.selectionCallback}
-              blinkCallback={this.onBlinkChange}
-              activeImageId={activeAlert ? activeAlert.image_id : activeImageId}
-              activeImageIndex={getActiveImageIndex(
-                activeGalaxy,
-                activeAlert,
-                activeImageIndex
-              )}
-            />
-          </div>
-          <ScatterPlotSelectorContainer
-            opened={openScatterPlot || false}
-            onSlideOutClick={this.handleSlideOutPlot}
+        {data && (
+          <NavDrawer
+            showNavDrawer
+            interactableToolbar
+            classes={styles.galaxyNavDrawer}
+            cardClasses={styles.container}
+            contentClasses={styles.galaxyDrawerContent}
+            drawerClasses={styles.galaxyDrawer}
+            navItems={this.generateNavItems(data)}
+            toolbarStyles={
+              activeGalaxy ? { backgroundColor: activeGalaxy.color } : null
+            }
+            toolbarTitle={activeGalaxy ? activeGalaxy.name : 'Galaxy Selector'}
+            toolbarActions={<Legend {...{ activeGalaxy, selectedData }} />}
+            menuOpenCallback={this.closeScatterPlot}
           >
-            <HubblePlot
-              className="hubble-plot"
-              {...{
-                options,
-                activeGalaxy,
-              }}
-              data={plottedData}
-              userHubblePlotCallback={this.userHubblePlotCallback}
-            />
-            <Navigation
-              handlePrevGalaxy={this.gotToPrevGalaxy}
-              handleNextGalaxy={this.goToNextGalaxy}
-            />
-          </ScatterPlotSelectorContainer>
-        </NavDrawer>
+            <div className="galaxy-selector-images--container">
+              <GalaxySelector
+                className={`galaxy-selector-${data.name}`}
+                {...{ selectedData, activeGalaxy, autoplay }}
+                data={getGalaxyPointData(activeGalaxy)}
+                alerts={activeGalaxy ? activeGalaxy.alerts : []}
+                image={image}
+                images={activeGalaxy ? activeGalaxy.images : []}
+                selectionCallback={this.selectionCallback}
+                blinkCallback={this.onBlinkChange}
+                activeImageId={
+                  activeAlert ? activeAlert.image_id : activeImageId
+                }
+                activeImageIndex={getActiveImageIndex(
+                  activeGalaxy,
+                  activeAlert,
+                  activeImageIndex
+                )}
+              />
+            </div>
+            <ScatterPlotSelectorContainer
+              opened={openScatterPlot || false}
+              onSlideOutClick={this.handleSlideOutPlot}
+            >
+              <HubblePlot
+                className="hubble-plot"
+                {...{
+                  options,
+                  activeGalaxy,
+                }}
+                data={plottedData}
+                userHubblePlotCallback={this.userHubblePlotCallback}
+              />
+              <Navigation
+                handlePrevGalaxy={this.gotToPrevGalaxy}
+                handleNextGalaxy={this.goToNextGalaxy}
+              />
+            </ScatterPlotSelectorContainer>
+          </NavDrawer>
+        )}
       </>
     );
   }

--- a/src/containers/GalaxySelectorContainer.jsx
+++ b/src/containers/GalaxySelectorContainer.jsx
@@ -27,7 +27,7 @@ class GalaxySelectorContainer extends React.PureComponent {
     this.state = {
       data: null,
       plottedData: null,
-      openScatterPlot: false,
+      plotIsOpen: false,
       activeGalaxy: null,
       activeAlert: null,
       activeImageIndex: 0,
@@ -63,8 +63,8 @@ class GalaxySelectorContainer extends React.PureComponent {
 
   chooseGalaxyAndClosePlot(event, activeGalaxy) {
     if (event) {
-      const { openScatterPlot } = this.state;
-      if (openScatterPlot) this.handleSlideOutPlot('close');
+      const { plotIsOpen } = this.state;
+      if (plotIsOpen) this.handleSlideOutPlot('close');
 
       const { alerts } = activeGalaxy;
       const activeAlert = alerts[0];
@@ -82,14 +82,14 @@ class GalaxySelectorContainer extends React.PureComponent {
   handleSlideOutPlot = () => {
     this.setState(prevState => ({
       ...prevState,
-      openScatterPlot: !prevState.openScatterPlot,
+      plotIsOpen: !prevState.plotIsOpen,
     }));
   };
 
   closeScatterPlot = () => {
     this.setState(prevState => ({
       ...prevState,
-      openScatterPlot: false,
+      plotIsOpen: false,
     }));
   };
 
@@ -102,11 +102,12 @@ class GalaxySelectorContainer extends React.PureComponent {
   };
 
   goToGalaxy(direction) {
-    const { activeGalaxy: oldActiveGalaxy, data } = this.state;
+    const { activeGalaxy: oldActiveGalaxy, data, plotIsOpen } = this.state;
+    const { answers, options } = this.props;
+    const { toggleDataPointsVisibility } = options || {};
     const lastIndex = data.length - 1;
     const oldIndex = data.indexOf(oldActiveGalaxy);
     const index = oldIndex + direction;
-
     let activeGalaxy = oldActiveGalaxy;
 
     if (index < 0) {
@@ -116,6 +117,12 @@ class GalaxySelectorContainer extends React.PureComponent {
     } else {
       activeGalaxy = data[index];
     }
+
+    const galSnSelected =
+      (getSelectedData(activeGalaxy, answers, toggleDataPointsVisibility) || [])
+        .length >= 2;
+
+    if (plotIsOpen && !galSnSelected) this.handleSlideOutPlot('close');
 
     const { alerts } = activeGalaxy;
     const activeAlert = alerts[0];
@@ -216,16 +223,13 @@ class GalaxySelectorContainer extends React.PureComponent {
       activeImageId,
       activeImageIndex,
       data,
-      openScatterPlot,
+      plotIsOpen,
       activeGalaxy,
       plottedData,
     } = this.state;
 
-    const {
-      answers,
-      options,
-      options: { toggleDataPointsVisibility, image, autoplay },
-    } = this.props;
+    const { answers, options } = this.props;
+    const { toggleDataPointsVisibility, image, autoplay } = options || {};
 
     const selectedData = getSelectedData(
       activeGalaxy,
@@ -273,7 +277,7 @@ class GalaxySelectorContainer extends React.PureComponent {
               />
             </div>
             <ScatterPlotSelectorContainer
-              opened={openScatterPlot || false}
+              opened={plotIsOpen || false}
               onSlideOutClick={this.handleSlideOutPlot}
             >
               <HubblePlot

--- a/src/data/pages/interpreting-hubble-plot-1.json
+++ b/src/data/pages/interpreting-hubble-plot-1.json
@@ -19,6 +19,7 @@
       "type": "GalaxySelector",
       "source": "/data/galaxies/galaxy_selector.json",
       "options": {
+        "autoplay": true,
         "toggleDataPointsVisibility": "251",
         "createUserHubblePlot": "252"
       }


### PR DESCRIPTION
When clicking previous/next galaxy buttons below slideout HubblePlot:
- If new activeGalaxy is already selected in GalaxySelector then highlight point in HubblePlot
- If the activeGalaxy is not selected in GalaxySelector then close HubblePlot and update GalaxySelector