### PR TITLE
[EPO-2836] pull in code and create new custom parent component for the Large Scale Structure (side by side)

### DIFF
--- a/src/components/charts/largeScaleStructurePlot/2DChart.jsx
+++ b/src/components/charts/largeScaleStructurePlot/2DChart.jsx
@@ -1,0 +1,189 @@
+import React from 'react';
+import ReactEcharts from 'echarts-for-react';
+import PropTypes from 'prop-types';
+import './large-scale-structure-plot.module.scss';
+import { formatValue } from '../../../lib/utilities';
+
+class LargeScaleStructure2DPlot extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.primaryColor = '#374785';
+    this.secondaryColor = '#A8D0E6';
+  }
+
+  formatTooltipPoint = (color, string) => {
+    return (
+      "<span style='display:inline-block;width:10px;height:10px;border-radius:50%;background-color:" +
+      color +
+      ";margin-right:5px;'></span><span>" +
+      string +
+      '</span>'
+    );
+  };
+
+  getTooltipFormat = params => {
+    const data = params.value;
+
+    if (Array.isArray(data)) {
+      const [ra, dec] = data;
+      return this.formatTooltipPoint(
+        this.secondaryColor,
+        `${ra.toFixed(2)}, ${dec.toFixed(2)}`
+      );
+    }
+
+    const { RA, Dec, redshift } = data;
+    return this.formatTooltipPoint(
+      this.primaryColor,
+      `${RA.toFixed(2)}, ${Dec.toFixed(2)}, ${redshift.toFixed(2)}`
+    );
+  };
+
+  getLegend = () => {
+    const { sliderVal, sliderIncrement } = this.props;
+    const selectedRange = sliderVal
+      ? `${sliderVal} - ${formatValue(sliderVal + sliderIncrement, 2)}`
+      : '';
+    return {
+      orient: 'vertical',
+      right: 5,
+      data: [
+        {
+          name: 'Data Point',
+          icon: 'circle',
+        },
+        {
+          name: 'Selected Range: ' + selectedRange,
+          icon: 'circle',
+        },
+      ],
+    };
+  };
+
+  getAxisInfo(title) {
+    return {
+      nameTextStyle: {
+        fontSize: 14,
+        fontWeight: 'bold',
+      },
+      name: title,
+      nameLocation: 'middle',
+      nameGap: 25,
+      axisLine: {
+        lineStyle: {
+          color: 'black',
+          opacity: 1,
+        },
+      },
+    };
+  }
+
+  getSeries(name, options) {
+    return {
+      name,
+      symbolSize: 8,
+      type: 'scatter',
+      encode: {
+        x: 'RA',
+        y: 'Dec',
+      },
+      legendHoverLink: true,
+      largeThreshold: 1000,
+      ...options,
+    };
+  }
+
+  getOption() {
+    const { data, selectedData, largeBool, trimBool } = this.props;
+
+    if (data) {
+      if (Object.keys(data).length === 0 || data.length === 0) return {};
+    }
+
+    return {
+      legend: this.getLegend(),
+      dataset: {
+        source: selectedData,
+        dimensions: ['RA', 'Dec', 'redshift'],
+      },
+      tooltip: {
+        borderColor: '#777',
+        borderWidth: 2,
+        formatter: this.getTooltipFormat,
+      },
+      xAxis: this.getAxisInfo('RA'),
+      yAxis: this.getAxisInfo('Dec'),
+
+      color: [this.secondaryColor, this.primaryColor],
+      series: [
+        this.getSeries('Data Point', {
+          data,
+          legendHoverLink: true,
+          large: largeBool,
+          itemStyle: {
+            opacity: !trimBool ? 0.25 : 1,
+          },
+        }),
+        this.getSeries('Highlighted Data Point', {
+          large: largeBool,
+          itemStyle: {
+            color: !trimBool ? this.primaryColor : this.secondaryColor,
+          },
+        }),
+      ],
+      textStyle: {
+        fontFamily: 'Roboto',
+      },
+      animation: false,
+      dataZoom: [
+        {
+          type: 'slider',
+          show: false,
+          xAxisIndex: [0],
+          minSpan: 60,
+        },
+        {
+          type: 'slider',
+          show: false,
+          yAxisIndex: [0],
+          minSpan: 60,
+        },
+        {
+          type: 'inside',
+          xAxisIndex: [0],
+          minSpan: 60,
+        },
+        {
+          type: 'inside',
+          yAxisIndex: [0],
+          minSpan: 60,
+        },
+      ],
+    };
+  }
+
+  render() {
+    return (
+      <>
+        <ReactEcharts style={{ height: '600px' }} option={this.getOption()} />
+      </>
+    );
+  }
+}
+
+LargeScaleStructure2DPlot.defaultProps = {
+  largeBool: true,
+  trimBool: false,
+};
+
+LargeScaleStructure2DPlot.propTypes = {
+  largeBool: PropTypes.bool,
+  trimBool: PropTypes.bool,
+  data: PropTypes.array,
+  selectedData: PropTypes.array,
+  sliderIncrement: PropTypes.number,
+  sliderVal: PropTypes.number,
+};
+
+export default LargeScaleStructure2DPlot;

--- a/src/components/charts/largeScaleStructurePlot/LargeScaleStructureScatterPlot.jsx
+++ b/src/components/charts/largeScaleStructurePlot/LargeScaleStructureScatterPlot.jsx
@@ -23,27 +23,18 @@ class LargeScaleStructureScatterPlot extends React.PureComponent {
   getOption() {
     const { dataProp, altData, shouldTrim, maximum } = this.props;
 
-    if (Object.keys(dataProp).length === 0 || altData === null) {
-      return {};
-    }
-    let bigData = dataProp;
-    let showData = dataProp;
-    if (altData !== null && altData.length !== 0) {
-      showData = altData;
+    if (dataProp) {
+      if (Object.keys(dataProp).length === 0 || altData === null) return {};
     }
 
-    let ptColor = '#a70000';
-    if (shouldTrim) {
-      bigData = [];
-      ptColor = '#A8D0E6';
-    } else {
-      ptColor = '#A8D0E6';
-    }
+    const isAltData = altData !== null && altData.length !== 0;
+    const showData = isAltData ? altData : dataProp;
+
     return {
       grid3D: {},
       dataset: {
         source: showData,
-        dimensions: ['RA', 'redshift', 'Dec'],
+        dimensions: ['RA', 'Dec', 'redshift'],
       },
       xAxis3D: this.getAxisOptions('RA'),
       zAxis3D: {
@@ -81,8 +72,13 @@ class LargeScaleStructureScatterPlot extends React.PureComponent {
       series: [
         {
           name: 'Big Dataset',
-          data: bigData,
           type: 'scatter3D',
+          encode: {
+            x: 'RA',
+            y: 'redshift',
+            z: 'Dec',
+          },
+          data: shouldTrim ? [] : dataProp,
           symbolSize: 2.5,
           itemStyle: {
             color: '#ffbaba',
@@ -93,9 +89,14 @@ class LargeScaleStructureScatterPlot extends React.PureComponent {
         {
           name: 'Highlight Dataset',
           type: 'scatter3D',
+          encode: {
+            x: 'RA',
+            y: 'redshift',
+            z: 'Dec',
+          },
           symbolSize: 2.5,
           itemStyle: {
-            color: ptColor,
+            color: '#A8D0E6',
             borderColor: '#374785',
             borderWidth: 0.01,
           },

--- a/src/components/charts/largeScaleStructurePlot/index.jsx
+++ b/src/components/charts/largeScaleStructurePlot/index.jsx
@@ -2,13 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Slider from 'react-md/lib/Sliders/Slider';
 import SelectionControl from 'react-md/lib/SelectionControls/SelectionControl';
-// import CheckBox from '../../site/icons/CheckBox';
-// import CheckBoxOutlineBlank from '../../site/icons/CheckBoxOutlineBlank';
 import { formatValue } from '../../../lib/utilities.js';
 import LargeScaleStructureScatterPlot from './LargeScaleStructureScatterPlot';
 import './large-scale-structure-plot.module.scss';
 
-class LargeScaleStructurePlot extends React.PureComponent {
+class LargeScaleStructure3DPlot extends React.PureComponent {
   constructor(props) {
     super(props);
 
@@ -76,7 +74,11 @@ class LargeScaleStructurePlot extends React.PureComponent {
   }
 }
 
-LargeScaleStructurePlot.propTypes = {
+LargeScaleStructure3DPlot.defaultProps = {
+  sliderIncrement: 0.01,
+};
+
+LargeScaleStructure3DPlot.propTypes = {
   data: PropTypes.array,
   selectedData: PropTypes.array,
   min: PropTypes.number,
@@ -86,4 +88,4 @@ LargeScaleStructurePlot.propTypes = {
   sliderCallback: PropTypes.func,
 };
 
-export default LargeScaleStructurePlot;
+export default LargeScaleStructure3DPlot;

--- a/src/components/page/blocks/WidgetBlock.jsx
+++ b/src/components/page/blocks/WidgetBlock.jsx
@@ -7,6 +7,7 @@ import GalaxiesSelector from '../../../containers/GalaxiesSelectorContainer.jsx'
 import HubblePlot from '../../../containers/HubblePlot2DContainer.jsx';
 import HubblePlot3D from '../../../containers/HubblePlot3DContainer.jsx';
 import LargeScaleStructurePlot from '../../../containers/LargeScaleStructurePlotContainer.jsx';
+import LargeScaleStructureComboPlot from '../../../containers/LargeScaleStructureComboPlotContainer.jsx';
 import GalacticProperties from '../../../containers/GalacticPropertiesContainer.jsx';
 import GalacticPropertiesCombo from '../../../containers/GalacticPropertiesComboContainer.jsx';
 
@@ -29,6 +30,7 @@ class WidgetBlock extends React.PureComponent {
       HubblePlot3D,
       GalacticProperties,
       LargeScaleStructurePlot,
+      LargeScaleStructureComboPlot,
       GalacticPropertiesCombo,
     };
 

--- a/src/containers/LargeScaleStructureComboPlotContainer.jsx
+++ b/src/containers/LargeScaleStructureComboPlotContainer.jsx
@@ -4,14 +4,15 @@ import filter from 'lodash/filter';
 import API from '../lib/API.js';
 import { extentFromSet, formatValue } from '../lib/utilities.js';
 import LargeScaleStructurePlot from '../components/charts/largeScaleStructurePlot/index.jsx';
+import LargeScaleStructure2DPlot from '../components/charts/largeScaleStructurePlot/2DChart.jsx';
 
-class LargeScaleStructurePlotContainer extends React.PureComponent {
+class LargeScaleStructureComboPlotContainer extends React.PureComponent {
   constructor(props) {
     super(props);
 
     this.state = {
-      data: null,
-      selectedData: null,
+      data: [],
+      selectedData: [],
       sliderVal1: null,
       min: null,
       max: null,
@@ -73,25 +74,40 @@ class LargeScaleStructurePlotContainer extends React.PureComponent {
     const { formattedData, selectedData, max, min, sliderVal } = this.state;
 
     return (
-      <>
-        <LargeScaleStructurePlot
-          data={formattedData}
-          {...{
-            min,
-            max,
-            sliderVal,
-            selectedData,
-          }}
-          sliderIncrement={this.increment}
-          sliderCallback={this.sliderCallback}
-        />
-      </>
+      <div className="container-flex spaced">
+        <div className="col padded col-width-50">
+          <LargeScaleStructure2DPlot
+            data={formattedData}
+            {...{
+              min,
+              max,
+              sliderVal,
+              selectedData,
+            }}
+            sliderIncrement={this.increment}
+            sliderCallback={this.sliderCallback}
+          />
+        </div>
+        <div className="col padded col-width-50">
+          <LargeScaleStructurePlot
+            data={formattedData}
+            {...{
+              min,
+              max,
+              sliderVal,
+              selectedData,
+            }}
+            sliderIncrement={this.increment}
+            sliderCallback={this.sliderCallback}
+          />
+        </div>
+      </div>
     );
   }
 }
 
-LargeScaleStructurePlotContainer.propTypes = {
+LargeScaleStructureComboPlotContainer.propTypes = {
   widget: PropTypes.object,
 };
 
-export default LargeScaleStructurePlotContainer;
+export default LargeScaleStructureComboPlotContainer;

--- a/src/data/pages/change-over-time-4.json
+++ b/src/data/pages/change-over-time-4.json
@@ -12,8 +12,15 @@
     "title": "Observing How the Universe Changed over Time",
     "link": "/discuss-report/"
   },
-  "layout": "TwoCol",
+  "layout": "SingleCol",
   "content": "<p>If you look at the concentration maps for the most recent times, you will notice that there are some areas that have a very low concentration of galaxies. Areas of very low galaxy concentrations are referred to as voids.</p><p>The changes in the large-scale structure are important to our understanding of the Universe. By seeing how the Universe has changed over time, cosmologists get clues to what processes might have created the structures in the first place.</p><p>Making these observations will give astronomers powerful new ways to tackle complex questions about the fundamental nature and interactions of matter and energy. The observations can be used to improve cosmological models of the Universe, which attempt to explain the profound connections between energy, matter, time and space. Perhaps we will be forced to make a new model that better explains the nature of dark energy and dark matter, which collectively account for 95% of the Universe. Perhaps we will discover new forms of energy or matter, new forces of nature, or even how the Universe was born.</p>",
+  "widgets": [
+    {
+      "type": "LargeScaleStructureComboPlot",
+      "source": "/data/sample_data/SDSS_SpecGals_DR8_25000.json",
+      "options": {}
+    }
+  ],
   "questionsByPage": [
     {
       "question": [


### PR DESCRIPTION
Structure of the 2d Chart has been massaged and updated to accept the data format currently being consumed by the 3d Chart. Both charts will update according to the slider in the 3d Chart (i.e. the selected data displayed).

Note: may need to break out the slider into the parent container to have more fluid functionality.