### PR TITLE
[B] GalaxySelector NavDrawer toggle opens/closes full NavDrawer menu

### DIFF
--- a/src/components/charts/shared/navDrawer/index.jsx
+++ b/src/components/charts/shared/navDrawer/index.jsx
@@ -15,36 +15,15 @@ class NavDrawer extends React.PureComponent {
     };
   }
 
-  componentDidUpdate(prevProps) {
-    const { navItems: prevNavItems } = prevProps;
-    const { navItems } = this.props;
-
-    if (navItems !== prevNavItems) {
-      this.handleMenuClose();
-    }
-  }
-
-  handleMenuOpen = () => {
-    const { menuOpenCallback } = this.props;
+  menuToggler = menuIsOpen => {
+    const { menuOpenCallback, menuCloseCallback } = this.props;
 
     this.setState(
       prevState => ({
         ...prevState,
-        menuIsOpen: true,
+        menuIsOpen,
       }),
-      menuOpenCallback
-    );
-  };
-
-  handleMenuClose = () => {
-    const { menuCloseCallback } = this.props;
-
-    this.setState(
-      prevState => ({
-        ...prevState,
-        menuIsOpen: false,
-      }),
-      menuCloseCallback
+      menuIsOpen ? menuOpenCallback : menuCloseCallback
     );
   };
 
@@ -72,15 +51,14 @@ class NavDrawer extends React.PureComponent {
     const { menuIsOpen } = this.state;
 
     const navClasses = classnames(navDrawerContainer, classes);
-
+    // console.log(this.props, this.state);
     return (
       <>
         {showNavDrawer && (
           <Card className={cardClasses}>
             <NavDrawerToolbar
               menuIsOpen={menuIsOpen}
-              onMenuOpen={this.handleMenuOpen}
-              onMenuClose={this.handleMenuClose}
+              toggleMenu={this.menuToggler}
               title={toolbarTitle}
               actions={toolbarActions}
               interactableToolbar={interactableToolbar}

--- a/src/components/charts/shared/navDrawer/toolbar/index.jsx
+++ b/src/components/charts/shared/navDrawer/toolbar/index.jsx
@@ -11,11 +11,15 @@ import ButtonIcon from '../../../../site/button/ButtonIcon';
 class NavDrawerToolbar extends React.PureComponent {
   icon = (Icon, srText) => <ButtonIcon srText={srText} Icon={Icon} />;
 
+  handleClick = () => {
+    const { toggleMenu, menuIsOpen } = this.props;
+
+    toggleMenu(!menuIsOpen);
+  };
+
   render() {
     const {
       title,
-      onMenuOpen,
-      onMenuClose,
       actions,
       menuIsOpen,
       interactableToolbar,
@@ -32,7 +36,7 @@ class NavDrawerToolbar extends React.PureComponent {
             disabled={!interactableToolbar}
             primary
             flat
-            onClick={menuIsOpen ? onMenuClose : onMenuOpen}
+            onClick={this.handleClick}
             iconEl={
               menuIsOpen
                 ? this.icon(CloseIcon, 'Close')
@@ -53,8 +57,7 @@ export default NavDrawerToolbar;
 NavDrawerToolbar.propTypes = {
   title: PropTypes.string,
   actions: PropTypes.node,
-  onMenuOpen: PropTypes.func,
-  onMenuClose: PropTypes.func,
+  toggleMenu: PropTypes.func,
   menuIsOpen: PropTypes.bool,
   interactableToolbar: PropTypes.bool,
   toolbarStyles: PropTypes.object,

--- a/src/containers/GalaxySelectorContainer.jsx
+++ b/src/containers/GalaxySelectorContainer.jsx
@@ -63,9 +63,6 @@ class GalaxySelectorContainer extends React.PureComponent {
 
   chooseGalaxyAndClosePlot(event, activeGalaxy) {
     if (event) {
-      const { plotIsOpen } = this.state;
-      if (plotIsOpen) this.handleSlideOutPlot('close');
-
       const { alerts } = activeGalaxy;
       const activeAlert = alerts[0];
 
@@ -75,6 +72,7 @@ class GalaxySelectorContainer extends React.PureComponent {
         activeImageIndex: 0,
         activeImageId: activeAlert.image_id,
         activeAlert: alerts[0],
+        plotIsOpen: false,
       }));
     }
   }
@@ -122,7 +120,7 @@ class GalaxySelectorContainer extends React.PureComponent {
       (getSelectedData(activeGalaxy, answers, toggleDataPointsVisibility) || [])
         .length >= 2;
 
-    if (plotIsOpen && !galSnSelected) this.handleSlideOutPlot('close');
+    if (plotIsOpen && !galSnSelected) this.handleSlideOutPlot();
 
     const { alerts } = activeGalaxy;
     const activeAlert = alerts[0];


### PR DESCRIPTION
Addresses an issue with the NavDrawer update cycle that was causing the full menu toggle "close" method to fire infinitely;