### PR TITLE
[EPO-3025] Histogram Tooltip pos uses mousePos & chartHeight

### DIFF
--- a/src/components/charts/shared/Tooltip.jsx
+++ b/src/components/charts/shared/Tooltip.jsx
@@ -18,8 +18,8 @@ class Tooltip extends React.PureComponent {
     const { show: isVisible, data: prevData } = prevProps;
     const dataEmpty = isEmpty(data);
     const $tooltip = d3Select(this.el.current);
-
     if (show && !isVisible && !dataEmpty) {
+      console.log(posX, posY);
       this.show($tooltip, data, posX, posY, show);
     } else if (show && isVisible && data !== prevData && !dataEmpty) {
       this.move($tooltip, data, posX, posY, show);
@@ -29,19 +29,30 @@ class Tooltip extends React.PureComponent {
   }
 
   getXPos(x, el) {
-    return `${x + 16 - el.node().getBoundingClientRect().width / 2}px`;
+    const { graph } = this.props;
+    const { width } = el.node().getBoundingClientRect();
+
+    if (graph === 'scatter') {
+      return `${x + 16 - width / 2}px`;
+    }
+
+    if (graph === 'histogram') {
+      return `${x - width / 2 < 0 ? 0 : x - width / 2}px`;
+    }
+
+    return `${x < 0 ? 0 : x}px`;
   }
 
   getYPos(y, el) {
     const { graph } = this.props;
-    const bBox = el.node().getBoundingClientRect();
+    const { height } = el.node().getBoundingClientRect();
 
     if (graph === 'scatter') {
-      return `${y - 24 - bBox.height}px`;
+      return `${y - 24 - height}px`;
     }
 
     if (graph === 'histogram') {
-      return `${y - bBox.height}px`;
+      return `${y + height}px`;
     }
 
     return `${y}px`;

--- a/src/components/site/imageLoader/index.jsx
+++ b/src/components/site/imageLoader/index.jsx
@@ -15,7 +15,15 @@ class ImageLoader extends React.PureComponent {
       loaded: false,
     };
 
+    this.timeFallback();
+  }
+
+  timeFallback = () => {
     setTimeout(this.handleLoading, 10000);
+  };
+
+  componentDidUnmount() {
+    clearTimeout(this.timeFallback);
   }
 
   handleLoading = () => {


### PR DESCRIPTION
Previously was using the position of the bar in the histogram to position tooltip but was causing inconsistencies: using mousePos and top of the chart is way more consistent although less elegant