### PR TITLE
[EPO-3106] GalacticProperties active point matches data

### DIFF
--- a/src/components/charts/galacticProperties/Point.jsx
+++ b/src/components/charts/galacticProperties/Point.jsx
@@ -16,7 +16,6 @@ class Point extends React.PureComponent {
     const $point = d3Select(this.svgEl.current);
     if (selected || hovered) {
       $point
-        .raise()
         .transition()
         .duration(800)
         .ease(d3EaseElastic)

--- a/src/components/charts/galacticProperties/index.jsx
+++ b/src/components/charts/galacticProperties/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
 import includes from 'lodash/includes';
 import classnames from 'classnames';
 import {
@@ -80,14 +81,13 @@ class GalacticProperties extends React.Component {
       yDomain: prevYDomain,
     } = prevProps;
 
-    return (
-      height !== prevHeight ||
-      width !== prevWidth ||
-      padding !== prevPadding ||
-      domain !== prevDomain ||
-      xDomain !== prevXDomain ||
-      yDomain !== prevYDomain
-    );
+    const diffDims =
+      height !== prevHeight || width !== prevWidth || padding !== prevPadding;
+    const diffDomains =
+      !isEqual(domain, prevDomain) ||
+      !isEqual(xDomain, prevXDomain) ||
+      !isEqual(yDomain, prevYDomain);
+    return diffDims || diffDomains;
   }
 
   getXScale() {

--- a/src/components/charts/galaxySelector/index.jsx
+++ b/src/components/charts/galaxySelector/index.jsx
@@ -36,7 +36,6 @@ class GalaxySelector extends React.PureComponent {
   }
 
   componentDidMount() {
-    // console.log(JSON.stringify(this.props));
     const { autoplay, preSelected, selectedData, data } = this.props;
     if (data) {
       this.updatePoints();

--- a/src/components/charts/hubblePlot/Point.jsx
+++ b/src/components/charts/hubblePlot/Point.jsx
@@ -18,7 +18,6 @@ class Point extends React.PureComponent {
     const $point = d3Select(this.svgEl.current);
     if (selected || hovered) {
       $point
-        .raise()
         .transition()
         .duration(800)
         .ease(d3EaseElastic)

--- a/src/components/charts/lightCurve/Point.jsx
+++ b/src/components/charts/lightCurve/Point.jsx
@@ -21,7 +21,10 @@ class Point extends React.PureComponent {
     const $point = d3Select(this.svgEl.current);
 
     if (selected || hovered) {
-      $point.raise().attr('r', this.baseSize * 5);
+      $point
+        .transition()
+        .duration(400)
+        .attr('r', this.baseSize * 5);
     } else {
       $point
         .transition()

--- a/src/components/charts/sizeDistancePlotter/Point.jsx
+++ b/src/components/charts/sizeDistancePlotter/Point.jsx
@@ -16,7 +16,6 @@ class Point extends React.PureComponent {
     const $point = d3Select(this.svgEl.current);
     if (selected || hovered) {
       $point
-        .raise()
         .transition()
         .duration(800)
         .ease(d3EaseElastic)

--- a/src/containers/GalaxiesSelectorContainer.jsx
+++ b/src/containers/GalaxiesSelectorContainer.jsx
@@ -84,7 +84,7 @@ class GalaxiesSelectorContainer extends React.PureComponent {
       .split('.')[0];
   }
 
-  updateActiveGalaxyState(activeGalaxy) {
+  updateActiveGalaxy(activeGalaxy) {
     const { activeGalaxy: prevActiveGalaxy } = this.state;
 
     if (prevActiveGalaxy !== activeGalaxy) {
@@ -103,11 +103,11 @@ class GalaxiesSelectorContainer extends React.PureComponent {
       updateAnswer(qId, allSelected);
     }
 
-    this.updateActiveGalaxyState(selection);
+    this.updateActiveGalaxy(selection);
   };
 
   userGalacticPropertiesCallback = d => {
-    this.updateActiveGalaxyState(d ? d[0] : null);
+    this.updateActiveGalaxy(d ? d[0] : null);
   };
 
   render() {


### PR DESCRIPTION
Removes `raise()` D3 method from Point components: this disruption of the DOM elements' order was in conflict with React's DOM updates in cases where the chart data was dynamic (user generated).  Shouldn't effect charts whose data does not change (or when it changes triggers full graph re-render) but pulled out `raise()` everywhere just to be safe