### PR TITLE
[B] Removes ImageLoader timeout

### DIFF
--- a/src/components/site/imageLoader/index.jsx
+++ b/src/components/site/imageLoader/index.jsx
@@ -15,20 +15,21 @@ class ImageLoader extends React.PureComponent {
       loaded: false,
     };
 
-    this.timeFallback();
+    // this.timeFallback = null;
+    // this.setTimeoutFallback();
   }
 
-  componentWillUnmount() {
-    clearTimeout(this.timeFallback);
-  }
+  // componentWillUnmount() {
+  //   clearTimeout(this.timeFallback);
+  // }
 
-  timeFallback = () => {
-    setTimeout(this.handleLoading, 10000);
-  };
+  // setTimeoutFallback() {
+  //   this.timeFallback = setTimeout(this.handleLoading, 10000);
+  // }
 
   handleLoading = () => {
+    // clearTimeout(this.timeFallback);
     this.setState(() => ({ loaded: true }));
-    clearTimeout(this.timeFallback);
   };
 
   render() {


### PR DESCRIPTION
The timeout and it's management in the lifecycle were intermittently
causing errors related to state change on unmounted components.  This
timeout is not really criutical and, arguably, percipitating a worse
experience than if an unloaded image always retained the loading graphic
so we're gonna comment out the timeout stuff for now and assess its
implementation later