### PR TITLE
[F] OrbitViewer details table fits inside component footprint

### DIFF
--- a/src/components/site/header/index.jsx
+++ b/src/components/site/header/index.jsx
@@ -26,6 +26,7 @@ class Header extends React.PureComponent {
           {toggleToc && (
             <Button
               className={`${styles.tocToggle} md-btn--toolbar md-toolbar--action-left`}
+              flat
               iconBefore
               iconEl={
                 tocVisability ? (

--- a/src/components/visualizations/orbitalViewer/Orbital.jsx
+++ b/src/components/visualizations/orbitalViewer/Orbital.jsx
@@ -32,6 +32,7 @@ const Orbital = ({
   initialized,
   initCallback,
   devMode,
+  activeVelocityCallback,
 }) => {
   // This reference will give us direct access to the mesh
   const mesh = useRef();
@@ -148,6 +149,13 @@ const Orbital = ({
   useEffect(() => {
     if (frameOverride) updatePoint(false, 1 / 60);
   }, [frameOverride]);
+
+  // Called whenever pointState changes
+  useEffect(() => {
+    if (active) {
+      activeVelocityCallback(point.velocity);
+    }
+  }, [point]);
 
   // Called every frame
   useFrame((state, delta) => {
@@ -273,6 +281,7 @@ Orbital.propTypes = {
   initCallback: PropTypes.func,
   initialized: PropTypes.bool,
   devMode: PropTypes.bool,
+  activeVelocityCallback: PropTypes.func,
 };
 
 export default Orbital;

--- a/src/components/visualizations/orbitalViewer/OrbitalDetails.jsx
+++ b/src/components/visualizations/orbitalViewer/OrbitalDetails.jsx
@@ -1,57 +1,72 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-// import Card from '../../site/card/index.js';
+import classnames from 'classnames';
 import Unit from '../../charts/shared/unit/index.jsx';
 import Table from '../../site/forms/table/index.jsx';
-import { getValue } from '../../../lib/utilities.js';
-// import { container } from './orbital-viewer.module.scss';
+import { getValue, toSigFigs } from '../../../lib/utilities.js';
+import {
+  details,
+  activeDetails,
+  detailsToggle,
+  detailsTable,
+} from './orbital-viewer.module.scss';
+import Button from '../../site/button/index.js';
 
-function OrbitalDetails(props) {
-  const { data } = props;
-  const { H, a, i, e, Principal_desig: scientificName } = data || {};
+function OrbitalDetails({ data, velocity }) {
+  const { H, a, i, e, Principal_desig: name } = data || {};
+  const [active, setActive] = useState(false);
+
+  function renderValueWithUnits(value, unitType, showUnit) {
+    if (!value) return '';
+    return (
+      <>
+        {getValue(unitType, value)}
+        {showUnit && <Unit type={unitType} />}
+      </>
+    );
+  }
 
   return (
-    <div>
-      <Table
-        className="details-table"
-        colTitles={[
-          'Name',
-          'Semi-major Axis',
-          'Eccentricity',
-          'Inclination',
-          'Absolute Magnitude',
-        ]}
-        includeRowTitles
-        rows={[
-          [
-            scientificName || '',
-            a ? (
-              <>
-                {getValue('semimajor_axis', a)}
-                <Unit type="semimajor_axis" />
-              </>
-            ) : (
-              ''
-            ),
-            e ? getValue('eccentricity', e) : '',
-            i ? (
-              <>
-                {getValue('inclination', i)}
-                <Unit type="inclination" />
-              </>
-            ) : (
-              ''
-            ),
-            H ? getValue('magnitude', H) : '',
-          ],
-        ]}
-      />
-    </div>
+    <>
+      <Button
+        className={detailsToggle}
+        flat
+        disabled={!data}
+        onClick={() => setActive(!active)}
+      >
+        {active ? 'Hide' : 'Object'} info
+      </Button>
+      <div
+        className={classnames(details, {
+          [activeDetails]: active,
+        })}
+      >
+        <Table
+          className={detailsTable}
+          includeRowTitles
+          rows={[
+            ['Scientific Name', name || ''],
+            [
+              'Semi-major Axis',
+              renderValueWithUnits(a, 'semimajor_axis', true),
+            ],
+            ['Eccentricity', renderValueWithUnits(e, 'eccentricity', false)],
+            ['Inclination', renderValueWithUnits(i, 'inclination', true)],
+            ['Absolute Magnitude', renderValueWithUnits(H, 'magnitude', false)],
+            [
+              'Speed',
+              renderValueWithUnits(toSigFigs(velocity, 3), 'velocity', true),
+            ],
+          ]}
+        />
+      </div>
+    </>
   );
 }
 
 OrbitalDetails.propTypes = {
   data: PropTypes.object,
+  velocity: PropTypes.number,
 };
 
 export default OrbitalDetails;

--- a/src/components/visualizations/orbitalViewer/Orbitals.jsx
+++ b/src/components/visualizations/orbitalViewer/Orbitals.jsx
@@ -7,6 +7,7 @@ function Orbitals({
   neos,
   activeNeo,
   selectionCallback,
+  activeVelocityCallback,
   playing,
   dayPerVizSec,
   stepDirection,
@@ -71,6 +72,7 @@ function Orbitals({
               dayPerVizSec,
               frameOverride,
               selectionCallback,
+              activeVelocityCallback,
             }}
             initCallback={dispatch}
           />
@@ -89,6 +91,7 @@ Orbitals.propTypes = {
   stepDirection: PropTypes.number,
   frameOverride: PropTypes.number,
   includeRefObjs: PropTypes.bool,
+  activeVelocityCallback: PropTypes.func,
 };
 
 export default Orbitals;

--- a/src/components/visualizations/orbitalViewer/index.jsx
+++ b/src/components/visualizations/orbitalViewer/index.jsx
@@ -7,13 +7,15 @@ import CameraController from './CameraController.jsx';
 import Orbitals from './Orbitals.jsx';
 import Controls from './controls/index.jsx';
 import PlaybackSpeed from './PlaybackSpeed.jsx';
+import OrbitalDetails from './OrbitalDetails.jsx';
 
-import { container } from './orbital-viewer.module.scss';
+import { container, orbitalCanvas } from './orbital-viewer.module.scss';
 
 function OrbitalViewer({ neos, activeNeo, updateActiveNeo, paused, pov }) {
   const speeds = [0.25, 0.5, 1, 10, 30];
 
   const [playing, setPlaying] = useState(!paused);
+  const [activeVelocity, setActiveVelocity] = useState(null);
   const [stepDirection, setStepDirection] = useState(1);
   const [frameOverride, setFrameOverride] = useState(null);
   const [dayPerVizSec, setDayPerVizSec] = useState(speeds[0]);
@@ -44,16 +46,18 @@ function OrbitalViewer({ neos, activeNeo, updateActiveNeo, paused, pov }) {
   };
 
   return (
-    <div>
+    <>
       <div className={container}>
+        <OrbitalDetails velocity={activeVelocity} data={activeNeo} />
         <PlaybackSpeed dayPerVizSec={dayPerVizSec} />
-        <Canvas invalidateFrameloop>
+        <Canvas invalidateFrameloop className={orbitalCanvas}>
           <CameraController pov={pov} />
           <Camera far={200000} near={0.1} fov={100} position={[0, 0, 500]} />
           <ambientLight intensity={0.9} />
           <Orbitals
             includeRefObjs
             selectionCallback={updateActiveNeo}
+            activeVelocityCallback={setActiveVelocity}
             {...{
               neos,
               activeNeo,
@@ -94,7 +98,7 @@ function OrbitalViewer({ neos, activeNeo, updateActiveNeo, paused, pov }) {
           />
         )}
       </div>
-    </div>
+    </>
   );
 }
 

--- a/src/components/visualizations/orbitalViewer/orbital-viewer.module.scss
+++ b/src/components/visualizations/orbitalViewer/orbital-viewer.module.scss
@@ -1,10 +1,16 @@
 .container {
   position: relative;
-  width: 600px;
-  max-width: 100%;
-  height: 600px;
-  max-height: 100%;
+  height: ($containerMaxWidth - $minPadding) / 2;
   background-color: $black;
+
+  @include respond($containerMaxWidth) {
+    height: calc((100vw - #{$minPadding} * 2) / 2);
+  }
+}
+
+.orbital-canvas {
+  position: relative;
+  z-index: 1;
 }
 
 .playback-speed {
@@ -18,8 +24,13 @@
 }
 
 .padded-drawer-inner {
+  width: ($containerMaxWidth - $minPadding) / 2;
   padding: 0 0 0 72px;
   outline: none;
+
+  @include respond($containerMaxWidth) {
+    width: calc((100vw - #{$minPadding} * 2) / 2);
+  }
 }
 
 //  Nav Drawer
@@ -75,4 +86,39 @@
   color: $white;
 }
 
+.details {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 2;
+  max-width: 0;
+  overflow: hidden;
+  transition: max-width $timing $durationSlow;
+
+  &.active-details {
+    width: 100%;
+    max-width: 350px;
+  }
+
+  .details-table {
+    margin-top: $minPadding * 2 + 36px;
+    background-color: $white;
+  }
+}
+
+.details-toggle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 3;
+  margin: $minPadding;
+  /* stylelint-disable-next-line declaration-no-important */
+  color: $white !important;
+  background-color: $error;
+
+  &:disabled {
+    background-color: $neutral20;
+  }
+}
 

--- a/src/containers/OrbitalViewerContainer.jsx
+++ b/src/containers/OrbitalViewerContainer.jsx
@@ -5,7 +5,7 @@ import API from '../lib/API.js';
 import ConditionalWrapper from '../components/ConditionalWrapper';
 import NavDrawer from '../components/charts/shared/navDrawer/index.jsx';
 import OrbitalViewer from '../components/visualizations/orbitalViewer/index.jsx';
-import OrbitalDetails from '../components/visualizations/orbitalViewer/OrbitalDetails.jsx';
+// import OrbitalDetails from '../components/visualizations/orbitalViewer/OrbitalDetails.jsx';
 
 import {
   avatarContainer,
@@ -102,10 +102,15 @@ class OrbitalViewerContainer extends React.PureComponent {
   }
 
   updateActiveNeo = activeNeo => {
-    this.setState(prevState => ({
-      ...prevState,
-      activeNeo,
-    }));
+    const { options } = this.props;
+    const { preSelected } = options || {};
+
+    if (!preSelected) {
+      this.setState(prevState => ({
+        ...prevState,
+        activeNeo,
+      }));
+    }
   };
 
   render() {
@@ -141,7 +146,6 @@ class OrbitalViewerContainer extends React.PureComponent {
             />
           )}
         </ConditionalWrapper>
-        {data && <OrbitalDetails data={activeNeo} />}
       </>
     );
   }

--- a/src/data/pages/close-to-earth-1.json
+++ b/src/data/pages/close-to-earth-1.json
@@ -16,6 +16,7 @@
       "type": "OrbitalViewer",
       "source": "/data/neos/three-neos.json",
       "options": {
+        "preSelected": true,
         "multiple": true,
         "paused": true,
         "pov": "top"

--- a/src/data/pages/close-to-earth-2.json
+++ b/src/data/pages/close-to-earth-2.json
@@ -19,6 +19,7 @@
       "type": "OrbitalViewer",
       "source": "/data/neos/aten.json",
       "options": {
+        "preSelected": true,
         "title": "Aten",
         "paused": true,
         "pov": "top"

--- a/src/data/pages/close-to-earth-3.json
+++ b/src/data/pages/close-to-earth-3.json
@@ -18,6 +18,7 @@
       "type": "OrbitalViewer",
       "source": "/data/neos/aten.json",
       "options": {
+        "preSelected": true,
         "paused": true,
         "pov": "side"
       }

--- a/src/data/pages/close-to-earth-4.json
+++ b/src/data/pages/close-to-earth-4.json
@@ -19,6 +19,7 @@
       "type": "OrbitalViewer",
       "source": "/data/neos/bennu.json",
       "options": {
+        "preSelected": true,
         "paused": true
       }
     }

--- a/src/data/pages/close-to-earth-5.json
+++ b/src/data/pages/close-to-earth-5.json
@@ -17,7 +17,10 @@
   "widgets": [
     {
       "type": "OrbitalViewer",
-      "source": "/data/neos/bennu.json"
+      "source": "/data/neos/bennu.json",
+      "options": {
+        "preSelected": true
+      }
     }
   ],
   "questionsByPage": [

--- a/src/data/pages/close-to-earth-6.json
+++ b/src/data/pages/close-to-earth-6.json
@@ -17,7 +17,10 @@
   "widgets": [
     {
       "type": "OrbitalViewer",
-      "source": "/data/neos/bennu.json"
+      "source": "/data/neos/bennu.json",
+      "options": {
+        "preSelected": true
+      }
     }
   ],
   "questionsByPage": [

--- a/src/data/pages/close-to-earth-7.json
+++ b/src/data/pages/close-to-earth-7.json
@@ -17,7 +17,10 @@
   "widgets": [
     {
       "type": "OrbitalViewer",
-      "source": "/data/neos/bennu.json"
+      "source": "/data/neos/bennu.json",
+      "options": {
+        "preSelected": true
+      }
     }
   ]
 }

--- a/src/data/pages/determining-orbits-1.json
+++ b/src/data/pages/determining-orbits-1.json
@@ -18,6 +18,7 @@
     {
       "type": "OrbitalViewer",
       "options": {
+        "preSelected": true,
         "showUserPlot": "10"
       }
     }

--- a/src/data/pages/milky-way-introduction.json
+++ b/src/data/pages/milky-way-introduction.json
@@ -1,0 +1,17 @@
+{
+  "id": "milkyway1",
+  "investigation": "milky-way",
+  "order": "00",
+  "title": "Introduction",
+  "slug": "introduction/",
+  "previous": {
+    "title": "",
+    "link": ""
+  },
+  "next": {
+    "title": "",
+    "link": ""
+  },
+  "layout": "TwoCol",
+  "content": "<p>Milky Way intro page</p>"
+}

--- a/src/data/pages/window-stars-introduction.json
+++ b/src/data/pages/window-stars-introduction.json
@@ -1,0 +1,17 @@
+{
+  "id": "windowstars1",
+  "investigation": "window-stars",
+  "order": "00",
+  "title": "Introduction",
+  "slug": "introduction/",
+  "previous": {
+    "title": "",
+    "link": ""
+  },
+  "next": {
+    "title": "",
+    "link": ""
+  },
+  "layout": "TwoCol",
+  "content": "<p>A Window to the Stars intro page</p>"
+}


### PR DESCRIPTION
Previously the details table was so big it had to go under the fold and below the OrbitViewer.  This update nests the details table within the OrbitViewer and provides a toggle button to reveal/hide the details.  Toggle button is disabled if no object details.