### PR TITLE
[EPO-3414] Add Investigation title to Header

### DIFF
--- a/src/components/charts/colorMixingTool/color-tool.module.scss
+++ b/src/components/charts/colorMixingTool/color-tool.module.scss
@@ -45,9 +45,9 @@
 }
 
 .button {
-  background: #d5d5d5;
   margin: 15px;
   line-height: 1;
+  background: #d5d5d5;
   transition: background $duration ease-in-out;
 
   &:hover {

--- a/src/components/site/header/header.module.scss
+++ b/src/components/site/header/header.module.scss
@@ -38,5 +38,17 @@
     .md-icon-separator {
       align-items: flex-start;
     }
-  };
+  }
+}
+
+.investigation-title {
+  @include headingPrimary;
+  margin: 0 $minPadding;
+  color: $white;
+}
+
+.page-title {
+  @include headingSecondary;
+  margin-left: $minPadding / 2;
+  color: $white;
 }

--- a/src/components/site/header/header.test.js
+++ b/src/components/site/header/header.test.js
@@ -12,9 +12,9 @@ test('Header renders without props', () => {
   expect(getByTestId('site-header')).toBeInTheDocument();
 });
 
-test('Header Logo alt text is Site Title', () => {
+test('Header Logo alt text is Investigation Title', () => {
   // Arrange
-  const { getByAltText, getByText } = render(<Header logo="fake/image/path" siteTitle={testTitle} />);
+  const { getByAltText, getByText } = render(<Header logo="fake/image/path" investigationTitle={testTitle} />);
   const logoLink = getByAltText(testTitle);
   // Assert
   expect(getByText(testTitle)).toBeInTheDocument();

--- a/src/components/site/header/index.jsx
+++ b/src/components/site/header/index.jsx
@@ -11,7 +11,7 @@ import styles from './header.module.scss';
 
 class Header extends React.PureComponent {
   render() {
-    const { siteTitle, toggleToc, tocVisability, logo } = this.props;
+    const { investigationTitle, toggleToc, tocVisability, logo } = this.props;
 
     return (
       <Toolbar
@@ -19,7 +19,6 @@ class Header extends React.PureComponent {
         data-testid="site-header"
         colored
         fixed
-        title={siteTitle}
         titleClassName="screen-reader-only"
         className="header-primary"
       >
@@ -44,6 +43,9 @@ class Header extends React.PureComponent {
               } Table of Contents`}</span>
             </Button>
           )}
+          <span className={styles.investigationTitle}>
+            {investigationTitle}
+          </span>
           <div className={styles.headerInner}>
             <Link to="/" className={logo && styles.logoWrapper}>
               <span className={`${logo && 'screen-reader-only'}`}>Home</span>
@@ -51,33 +53,23 @@ class Header extends React.PureComponent {
                 <img
                   aria-hidden
                   src={logo}
-                  alt={siteTitle}
+                  alt={investigationTitle}
                   className={styles.siteLogo}
                 />
               )}
             </Link>
           </div>
         </div>
-        {/* <LinearProgress className="{styles.pageProgress} value={pageProgress} /> */}
-        {/*        <SiteNav
-            menuOpen={menuOpen}
-            handleClose={this.closeMenu}
-            handleClick={this.clickHandler}
-          /> */}
       </Toolbar>
     );
   }
 }
 
 Header.propTypes = {
-  siteTitle: PropTypes.string,
+  investigationTitle: PropTypes.string,
   tocVisability: PropTypes.bool,
   toggleToc: PropTypes.func,
   logo: PropTypes.string,
-};
-
-Header.defaultProps = {
-  siteTitle: ``,
 };
 
 export default Header;

--- a/src/components/site/selectField/styles.module.scss
+++ b/src/components/site/selectField/styles.module.scss
@@ -1,6 +1,7 @@
 .md-select-container {
   :global {
     @include react-md-select-fields;
+
     .md-menu--select-field {
       position: relative;
     }

--- a/src/components/site/slider/styles.module.scss
+++ b/src/components/site/slider/styles.module.scss
@@ -10,6 +10,7 @@
       border-radius: 50%;
 
       &.md-slider-thumb--continuous-off {
+        /* stylelint-disable-next-line declaration-no-important */
         top: -9px !important;
       }
 


### PR DESCRIPTION
- Add `allInvestigationsJson` query to get all investigations' title.
- Filter titles returned on current `investigation` prop provided.