### PR TITLE
[F] Add page numbers to header and table of contents

### DIFF
--- a/src/components/site/header/header.test.js
+++ b/src/components/site/header/header.test.js
@@ -14,11 +14,19 @@ test('Header renders without props', () => {
 
 test('Header Logo alt text is Investigation Title', () => {
   // Arrange
-  const { getByAltText, getByText } = render(<Header logo="fake/image/path" investigationTitle={testTitle} />);
+  const { getByAltText, getByText, queryByText } = render(<Header logo="fake/image/path" investigationTitle={testTitle} />);
   const logoLink = getByAltText(testTitle);
   // Assert
   expect(getByText(testTitle)).toBeInTheDocument();
+  expect(queryByText(`${testTitle}: Page`)).toBe(null);
   expect(logoLink).toBeInTheDocument();
+});
+
+test('Header renders page number if provided', () => {
+  // Arrange
+  const { getByText } = render(<Header logo="fake/image/path" investigationTitle={testTitle} pageNumber={22} />);
+  // Assert
+  expect(getByText(`${testTitle}: Page 22`)).toBeInTheDocument();
 });
 
 test('When TOC is visible Header TOC toggle reads "Close..."', () => {

--- a/src/components/site/header/index.jsx
+++ b/src/components/site/header/index.jsx
@@ -1,9 +1,6 @@
 import { Link } from 'gatsby';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { globalHistory } from '@reach/router';
-import reactn from 'reactn';
-import find from 'lodash/find';
 import { Toolbar } from 'react-md';
 import Button from '../button/index';
 import ButtonIcon from '../button/ButtonIcon';
@@ -12,30 +9,15 @@ import Menu from '../icons/Menu';
 
 import styles from './header.module.scss';
 
-@reactn
 class Header extends React.PureComponent {
   render() {
-    const {
-      location: { pathname },
-    } = globalHistory;
-    const { pageId } = this.global;
     const {
       investigationTitle,
       toggleToc,
       tocVisability,
       logo,
-      pages,
+      pageNumber,
     } = this.props;
-
-    const pathnameArr = pathname.split('/');
-    const path = pathnameArr[pathnameArr.length - 2];
-
-    const currentPage = find(pages, { id: pageId });
-    const { pageNumber } = currentPage || {};
-    const currentPageNumber =
-      !pageNumber || path === '' || path === 'last-page'
-        ? null
-        : `: Page ${pageNumber}`;
 
     return (
       <Toolbar
@@ -69,7 +51,7 @@ class Header extends React.PureComponent {
           )}
           <span className={styles.investigationTitle}>
             {investigationTitle}
-            {currentPageNumber}
+            {pageNumber && `: Page ${pageNumber}`}
           </span>
           <div className={styles.headerInner}>
             <Link to="/" className={logo && styles.logoWrapper}>
@@ -95,7 +77,7 @@ Header.propTypes = {
   tocVisability: PropTypes.bool,
   toggleToc: PropTypes.func,
   logo: PropTypes.string,
-  pages: PropTypes.array,
+  pageNumber: PropTypes.number,
 };
 
 export default Header;

--- a/src/components/site/header/index.jsx
+++ b/src/components/site/header/index.jsx
@@ -1,6 +1,9 @@
 import { Link } from 'gatsby';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { globalHistory } from '@reach/router';
+import reactn from 'reactn';
+import find from 'lodash/find';
 import { Toolbar } from 'react-md';
 import Button from '../button/index';
 import ButtonIcon from '../button/ButtonIcon';
@@ -9,9 +12,30 @@ import Menu from '../icons/Menu';
 
 import styles from './header.module.scss';
 
+@reactn
 class Header extends React.PureComponent {
   render() {
-    const { investigationTitle, toggleToc, tocVisability, logo } = this.props;
+    const {
+      location: { pathname },
+    } = globalHistory;
+    const { pageId } = this.global;
+    const {
+      investigationTitle,
+      toggleToc,
+      tocVisability,
+      logo,
+      pages,
+    } = this.props;
+
+    const pathnameArr = pathname.split('/');
+    const path = pathnameArr[pathnameArr.length - 2];
+
+    const currentPage = find(pages, { id: pageId });
+    const { pageNumber } = currentPage || {};
+    const currentPageNumber =
+      !pageNumber || path === '' || path === 'last-page'
+        ? null
+        : `: Page ${pageNumber}`;
 
     return (
       <Toolbar
@@ -45,6 +69,7 @@ class Header extends React.PureComponent {
           )}
           <span className={styles.investigationTitle}>
             {investigationTitle}
+            {currentPageNumber}
           </span>
           <div className={styles.headerInner}>
             <Link to="/" className={logo && styles.logoWrapper}>
@@ -70,6 +95,7 @@ Header.propTypes = {
   tocVisability: PropTypes.bool,
   toggleToc: PropTypes.func,
   logo: PropTypes.string,
+  pages: PropTypes.array,
 };
 
 export default Header;

--- a/src/components/site/tableOfContents/index.jsx
+++ b/src/components/site/tableOfContents/index.jsx
@@ -16,7 +16,13 @@ class TableOfContents extends React.PureComponent {
       ...filter(navLinks, link => link.investigation === investigation).map(
         link => {
           if (link.divider || link.subheader) return link;
-          const { title, id, investigation: linkBaseUrl, slug } = link;
+          const {
+            title,
+            pageNumber,
+            id,
+            investigation: linkBaseUrl,
+            slug,
+          } = link;
           const baseUrl = linkBaseUrl && useBaseUrl ? `/${linkBaseUrl}/` : '/';
           const isActive = this.isActivePage(id);
 
@@ -24,7 +30,7 @@ class TableOfContents extends React.PureComponent {
             component: Link,
             label: title,
             to: baseUrl + slug,
-            primaryText: title,
+            primaryText: `${pageNumber}. ${title}`,
             leftIcon: <Check />,
             active: isActive,
             className: classnames('toc-link', `link--page-id--${id}`, {

--- a/src/containers/EndingContainer.jsx
+++ b/src/containers/EndingContainer.jsx
@@ -21,6 +21,10 @@ class LastPage extends React.PureComponent {
     };
   }
 
+  componentDidMount() {
+    this.dispatch.updatePageId(null);
+  }
+
   handleAnswersReset = () => {
     const { envInvestigation } = this.state;
     const globalStateLs = this.global.answers;

--- a/src/containers/LandingContainer.jsx
+++ b/src/containers/LandingContainer.jsx
@@ -20,6 +20,10 @@ class InvestigationsLanding extends React.PureComponent {
     };
   }
 
+  componentDidMount() {
+    this.dispatch.updatePageId(null);
+  }
+
   handleAnswersReset = () => {
     const { envInvestigation } = this.state;
     const globalStateLs = this.global.answers;

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -24,16 +24,27 @@ class Layout extends React.Component {
     } = pageContext;
     const id = investigationId || envInvestigationId;
     const investigation = find(investigations, { id });
+    const pages = filter(allInvestigationsPages, ['investigation', id]);
 
     this.state = {
       tocIsOpen: false,
       investigationTitle: investigation ? investigation.title : '',
-      pages: filter(allInvestigationsPages, ['investigation', id]),
+      pages: this.massagePageData(pages),
     };
 
     this.store = new GlobalStore(this.getInitialGlobals());
     this.store.addCallbacks();
     this.store.addReducers();
+  }
+
+  massagePageData(pages) {
+    return pages.map((page, index) => {
+      const pageUpdate = {
+        ...page,
+        pageNumber: index + 1,
+      };
+      return pageUpdate;
+    });
   }
 
   getTotalQAs() {
@@ -101,6 +112,12 @@ class Layout extends React.Component {
     }));
   };
 
+  getHeaderPages(pages) {
+    return pages.map(page => {
+      return { id: page.id, pageNumber: page.pageNumber };
+    });
+  }
+
   render() {
     const { tocIsOpen, pages, investigationTitle } = this.state;
     const { children, pageContext } = this.props;
@@ -116,6 +133,7 @@ class Layout extends React.Component {
           tocVisability={tocIsOpen}
           toggleToc={investigation && this.toggleToc}
           logo={logo}
+          pages={this.getHeaderPages(pages)}
         />
         {investigation && (
           <TableOfContents

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -24,27 +24,19 @@ class Layout extends React.Component {
     } = pageContext;
     const id = investigationId || envInvestigationId;
     const investigation = find(investigations, { id });
-    const pages = filter(allInvestigationsPages, ['investigation', id]);
 
     this.state = {
       tocIsOpen: false,
       investigationTitle: investigation ? investigation.title : '',
-      pages: this.massagePageData(pages),
+      pages: filter(allInvestigationsPages, [
+        'investigation',
+        id,
+      ]).map((page, i) => ({ ...page, pageNumber: i + 1 })),
     };
 
     this.store = new GlobalStore(this.getInitialGlobals());
     this.store.addCallbacks();
     this.store.addReducers();
-  }
-
-  massagePageData(pages) {
-    return pages.map((page, index) => {
-      const pageUpdate = {
-        ...page,
-        pageNumber: index + 1,
-      };
-      return pageUpdate;
-    });
   }
 
   getTotalQAs() {
@@ -112,10 +104,13 @@ class Layout extends React.Component {
     }));
   };
 
-  getHeaderPages(pages) {
-    return pages.map(page => {
-      return { id: page.id, pageNumber: page.pageNumber };
-    });
+  getCurrentPageNumber() {
+    const { pageId: id } = this.global;
+    const { pages } = this.state;
+    const currentPage = find(pages, { id });
+    const { pageNumber } = currentPage || {};
+
+    return pageNumber;
   }
 
   render() {
@@ -129,11 +124,10 @@ class Layout extends React.Component {
       <>
         <SEO title={investigation || 'Investigation'} />
         <Header
-          investigationTitle={investigationTitle}
+          {...{ investigationTitle, logo }}
+          pageNumber={this.getCurrentPageNumber()}
           tocVisability={tocIsOpen}
           toggleToc={investigation && this.toggleToc}
-          logo={logo}
-          pages={this.getHeaderPages(pages)}
         />
         {investigation && (
           <TableOfContents

--- a/src/state/GlobalStore.js
+++ b/src/state/GlobalStore.js
@@ -56,6 +56,13 @@ class GlobalStore {
         visitedPages: prevVisitedPages,
       } = global;
 
+      if (!pageId) {
+        return {
+          ...global,
+          pageId,
+        };
+      }
+
       if (!prevPageId) {
         return {
           ...global,


### PR DESCRIPTION
Used the pages' index (+ 1) and stored that in the pages array as 'pageNumber' before storing the pages into global store.

Used that pages array in the Table of contents simply by adding the new pageNumber index in the primaryText.

Pushed a filtered array of pages (only page.id and page.pageNumber) into the Header component. Used the 'lodash/find' to get the page from my new pages array and set that to a pageNumber variable that outputs ": Page {pageNumber}". Imported globalHistory from '@reach/router' and used it's location.pathname prop to catch the page url for the 'last-page' instance as well as the introduction page.