### PR TITLE
[EPO-3416] Add question numbers to investigations

### DIFF
--- a/src/components/qas/index.jsx
+++ b/src/components/qas/index.jsx
@@ -18,7 +18,7 @@ class QAs extends React.PureComponent {
     return (
       <div className="qas">
         {questions.map(question => {
-          const q = question.question;
+          const { question: q, number } = question;
           const primeQ = q[0];
           const { id, questionType } = primeQ;
           const key = `qa-${id}`;
@@ -28,6 +28,7 @@ class QAs extends React.PureComponent {
               <div className={qa} key={key}>
                 <QACompound
                   activeId={activeQuestionId}
+                  questionNumber={+number}
                   questions={q}
                   answers={answers}
                   handleAnswerSelect={updateAnswer}
@@ -42,6 +43,7 @@ class QAs extends React.PureComponent {
             <QA
               key={key}
               questionType={questionType}
+              questionNumber={+number}
               question={primeQ}
               answer={answer}
               activeId={activeQuestionId}

--- a/src/components/qas/questions/qaCalculator/index.jsx
+++ b/src/components/qas/questions/qaCalculator/index.jsx
@@ -154,7 +154,7 @@ class QACalculator extends React.PureComponent {
   };
 
   render() {
-    const { question, answer, activeId } = this.props;
+    const { questionNumber, question, answer, activeId } = this.props;
     const { answerable, value, hasFocus } = this.state;
 
     const { questionType } = question;
@@ -181,6 +181,8 @@ class QACalculator extends React.PureComponent {
     const { inputs, equation } = this.calculator[questionType];
     const FindEquation = equation || null;
 
+    const updatedLabel = questionNumber ? `${questionNumber}. ${label}` : label;
+
     return (
       <Card
         className={cardClasses}
@@ -189,7 +191,7 @@ class QACalculator extends React.PureComponent {
         onExpanderClick={() => {}}
       >
         <CardText>
-          <div className={labelClasses}>{label}</div>
+          <div className={labelClasses}>{updatedLabel}</div>
           <div className="container">
             {inputs &&
               inputs.map((input, i) => {
@@ -269,6 +271,7 @@ class QACalculator extends React.PureComponent {
 QACalculator.propTypes = {
   activeId: PropTypes.string,
   question: PropTypes.object.isRequired,
+  questionNumber: PropTypes.number,
   answerHandler: PropTypes.func,
   answer: PropTypes.object,
 };

--- a/src/components/qas/questions/qaCompound/index.jsx
+++ b/src/components/qas/questions/qaCompound/index.jsx
@@ -28,14 +28,20 @@ class QACompound extends React.PureComponent {
   };
 
   render() {
-    const { questions, activeId, answers, handleAnswerSelect } = this.props;
+    const {
+      questionNumber,
+      questions,
+      activeId,
+      answers,
+      handleAnswerSelect,
+    } = this.props;
     const { hasFocus } = this.state;
     const cardClasses = classnames(qaCard, { [active]: hasFocus });
 
     return (
       <Card className={cardClasses}>
         <div className="qa-wrapper">
-          {questions.map(question => {
+          {questions.map((question, i) => {
             const { id, questionType, options } = question;
             const QACompoundComponent = this.qaTypes[questionType];
             if (!QACompoundComponent) return null;
@@ -48,9 +54,11 @@ class QACompound extends React.PureComponent {
                 focusCallback={this.updateActive}
                 answerHandler={handleAnswerSelect}
                 handleAnswerSelect={handleAnswerSelect}
+                firstQuestion={i === 0}
                 {...{
                   question,
                   activeId,
+                  questionNumber,
                   questionType,
                   options,
                 }}
@@ -65,6 +73,7 @@ class QACompound extends React.PureComponent {
 
 QACompound.propTypes = {
   handleAnswerSelect: PropTypes.func,
+  questionNumber: PropTypes.number,
   questions: PropTypes.array,
   answers: PropTypes.object,
   activeId: PropTypes.string,

--- a/src/components/qas/questions/qaExpansionList/QAExpansionPanel.jsx
+++ b/src/components/qas/questions/qaExpansionList/QAExpansionPanel.jsx
@@ -11,6 +11,7 @@ import styles from './styles.module.scss';
 class QAExpansionPanel extends React.PureComponent {
   render() {
     const {
+      questionNumber,
       question,
       answer,
       active,
@@ -33,11 +34,13 @@ class QAExpansionPanel extends React.PureComponent {
       unstyled: !active,
     });
 
+    const updatedLabel = `<span class=${styles.labelWithNumber}>${questionNumber}. ${label}</span>`;
+
     return (
       <Question
         columnWidths={columnWidths}
         focused={focused}
-        label={<div dangerouslySetInnerHTML={renderDef(label)} />}
+        label={<div dangerouslySetInnerHTML={renderDef(updatedLabel)} />}
         className={questionClasses}
         contentClassName={styles.answer}
         expanded={isExpanded}
@@ -67,6 +70,7 @@ class QAExpansionPanel extends React.PureComponent {
 
 QAExpansionPanel.propTypes = {
   answer: PropTypes.object,
+  questionNumber: PropTypes.number,
   question: PropTypes.object,
   active: PropTypes.bool,
   columnWidths: PropTypes.array,

--- a/src/components/qas/questions/qaExpansionList/index.jsx
+++ b/src/components/qas/questions/qaExpansionList/index.jsx
@@ -12,6 +12,7 @@ class QAExpansionList extends React.PureComponent {
 
   render() {
     const {
+      questionNumber,
       question,
       answer,
       answerHandler: cancelHandler,
@@ -26,6 +27,7 @@ class QAExpansionList extends React.PureComponent {
         <QAExpansionPanel
           {...this.props}
           key={`qa-${id}`}
+          questionNumber={questionNumber}
           question={question}
           answer={answer}
           active={activeId === id}
@@ -40,6 +42,7 @@ class QAExpansionList extends React.PureComponent {
 }
 
 QAExpansionList.propTypes = {
+  questionNumber: PropTypes.number,
   question: PropTypes.object,
   answer: PropTypes.object,
   activeId: PropTypes.string,

--- a/src/components/qas/questions/qaExpansionList/styles.module.scss
+++ b/src/components/qas/questions/qaExpansionList/styles.module.scss
@@ -14,7 +14,8 @@
       padding: $minPadding;
     }
 
-    .md-fake-btn .md-text, .md-fake-btn .md-text p {
+    .md-fake-btn .md-text,
+    .md-fake-btn .md-text p {
       @include copySecondary;
       /* stylelint-disable-next-line declaration-no-important */
       min-width: 0 !important;
@@ -30,7 +31,6 @@
       }
     }
   }
-
 
   &.active {
     .answer {
@@ -48,7 +48,8 @@
         height: auto;
       }
 
-      .md-fake-btn .md-text, .md-fake-btn .md-text p {
+      .md-fake-btn .md-text,
+      .md-fake-btn .md-text p {
         color: $basePrimary;
       }
     }
@@ -60,7 +61,8 @@
         padding: $minPadding $minPadding 0;
       }
 
-      .md-fake-btn .md-text, .md-fake-btn .md-text p {
+      .md-fake-btn .md-text,
+      .md-fake-btn .md-text p {
         color: $basePrimary;
       }
     }
@@ -76,7 +78,8 @@
   }
 
   .answer {
-    .answer-pre, .answer-post {
+    .answer-pre,
+    .answer-post {
       p {
         display: inline;
       }
@@ -90,5 +93,11 @@
       padding: $minPadding;
       border: 0;
     }
+  }
+}
+
+.label-with-number {
+  p {
+    display: inline;
   }
 }

--- a/src/components/qas/questions/qaMultiSelect/index.jsx
+++ b/src/components/qas/questions/qaMultiSelect/index.jsx
@@ -109,7 +109,14 @@ class QAMultiSelect extends React.PureComponent {
   };
 
   render() {
-    const { ids, question, activeId, answer } = this.props;
+    const {
+      ids,
+      firstQuestion,
+      questionNumber,
+      question,
+      activeId,
+      answer,
+    } = this.props;
     const {
       id,
       label,
@@ -130,6 +137,12 @@ class QAMultiSelect extends React.PureComponent {
       [styles.answerable]: answerable || answered || active,
     });
 
+    const updatedLabel = questionNumber ? `${questionNumber}. ${label}` : label;
+    const updatedLabelPre =
+      questionNumber && firstQuestion
+        ? `${questionNumber}. ${labelPre}`
+        : labelPre;
+
     return (
       <ConditionalWrapper
         condition={questionType !== 'compoundSelect'}
@@ -137,7 +150,7 @@ class QAMultiSelect extends React.PureComponent {
       >
         <div className={selectClasses}>
           {labelPre && (
-            <span className={styles.labelPre}>{labelPre}&nbsp;</span>
+            <span className={styles.labelPre}>{updatedLabelPre}&nbsp;</span>
           )}
           <DropdownMenu
             id="multi-select"
@@ -154,7 +167,7 @@ class QAMultiSelect extends React.PureComponent {
             // visible={answerable}
           >
             <span
-              label={label}
+              label={updatedLabel}
               className={classnames(
                 'toggle',
                 styles.multiSelectOptions,
@@ -173,8 +186,14 @@ class QAMultiSelect extends React.PureComponent {
   }
 }
 
+QAMultiSelect.defaultProps = {
+  firstQuestion: true,
+};
+
 QAMultiSelect.propTypes = {
   handleAnswerSelect: PropTypes.func,
+  firstQuestion: PropTypes.bool,
+  questionNumber: PropTypes.number,
   question: PropTypes.object,
   answer: PropTypes.object,
   activeId: PropTypes.string,

--- a/src/components/qas/questions/qaSelect/index.jsx
+++ b/src/components/qas/questions/qaSelect/index.jsx
@@ -78,7 +78,14 @@ class QASelect extends React.PureComponent {
   };
 
   render() {
-    const { ids, question, activeId, answer } = this.props;
+    const {
+      ids,
+      firstQuestion,
+      question,
+      questionNumber,
+      activeId,
+      answer,
+    } = this.props;
     const {
       id,
       label,
@@ -105,6 +112,22 @@ class QASelect extends React.PureComponent {
     const selectClasses = classnames({
       [styles.hideLabel]: labelPre || labelPost,
     });
+    const labelPreClasses = classnames(
+      styles.labelPre,
+      qaStyles.labelWithNumber
+    );
+
+    const hasQANumber = questionNumber && firstQuestion;
+    const updatedLabel =
+      hasQANumber && label && !labelPre ? `${questionNumber}. ${label}` : label;
+    const updatedLabelPre =
+      hasQANumber && !label && labelPre
+        ? `${questionNumber}. ${labelPre}`
+        : labelPre;
+    const onlyQaNumber =
+      hasQANumber && !labelPre && !label && labelPost
+        ? `${questionNumber}. `
+        : null;
 
     return (
       <ConditionalWrapper
@@ -112,14 +135,19 @@ class QASelect extends React.PureComponent {
         wrapper={children => <Card className={cardClasses}>{children}</Card>}
       >
         <div className={wrapperClasses}>
-          {labelPre && (
-            <span className={styles.labelPre}>{labelPre}&nbsp;</span>
+          {updatedLabelPre && (
+            <span className={labelPreClasses}>
+              {updatedLabelPre || onlyQaNumber}&nbsp;
+            </span>
+          )}
+          {onlyQaNumber && !updatedLabelPre && (
+            <span className={labelPreClasses}>{onlyQaNumber}&nbsp;</span>
           )}
           <Select
             id={`qa-select-${id}`}
             className={selectClasses}
             options={options}
-            label={label || srLabel || placeholder}
+            label={updatedLabel || srLabel || placeholder}
             name={label || srLabel || placeholder}
             value={answered ? answer.content || answer.data : 'DEFAULT'}
             handleBlur={this.handler}
@@ -139,8 +167,14 @@ class QASelect extends React.PureComponent {
   }
 }
 
+QASelect.defaultProps = {
+  firstQuestion: true,
+};
+
 QASelect.propTypes = {
   handleAnswerSelect: PropTypes.func,
+  firstQuestion: PropTypes.bool,
+  questionNumber: PropTypes.number,
   question: PropTypes.object,
   answer: PropTypes.object,
   activeId: PropTypes.string,

--- a/src/components/qas/questions/qaTextInput/index.jsx
+++ b/src/components/qas/questions/qaTextInput/index.jsx
@@ -85,7 +85,13 @@ class TextInput extends React.PureComponent {
   };
 
   render() {
-    const { question, answer, activeId } = this.props;
+    const {
+      firstQuestion,
+      question,
+      questionNumber,
+      answer,
+      activeId,
+    } = this.props;
     const { hasFocus, answerable } = this.state;
     const {
       id,
@@ -102,7 +108,7 @@ class TextInput extends React.PureComponent {
     const cardClasses = classnames(qaStyles.qaCard, {
       [qaStyles.active]: hasFocus,
     });
-    const labelClasses = classnames(styles.label, {
+    const labelClasses = classnames(styles.label, qaStyles.labelWithNumber, {
       answered,
       unanswered: !answered,
       [styles.answerable]: answerable || answered || active,
@@ -115,20 +121,38 @@ class TextInput extends React.PureComponent {
       [styles.inlineInput]: labelPre || labelPost,
     });
 
+    const hasQANumber = questionNumber && firstQuestion;
+    const updatedLabel =
+      hasQANumber && label && !labelPre ? `${questionNumber}. ${label}` : label;
+    const updatedLabelPre =
+      hasQANumber && !label && labelPre
+        ? `${questionNumber}. ${labelPre}`
+        : labelPre;
+    const onlyQaNumber =
+      hasQANumber && !labelPre && !label && labelPost
+        ? `${questionNumber}. `
+        : null;
+
     return (
       <ConditionalWrapper
         condition={!includes(questionType, 'compoundInput')}
         wrapper={children => <Card className={cardClasses}>{children}</Card>}
       >
-        {labelPre && <span className={labelClasses}>{labelPre}&nbsp;</span>}
+        {updatedLabelPre && (
+          <span className={labelClasses}>{updatedLabelPre}&nbsp;</span>
+        )}
+        {onlyQaNumber && !updatedLabelPre && (
+          <span className={styles.labelPre}>{onlyQaNumber}&nbsp;</span>
+        )}
         <TextField
           id={`text-${isTextArea ? 'area' : 'input'}-${id}`}
           className={fieldClasses}
           type="text"
           label={
             <div
+              className={qaStyles.labelWithNumber}
               dangerouslySetInnerHTML={renderDef(
-                label ||
+                updatedLabel ||
                   `Complete this statement by filling in the blank: ${labelPre}, blank, ${labelPost}`
               )}
             />
@@ -151,8 +175,14 @@ class TextInput extends React.PureComponent {
   }
 }
 
+TextInput.defaultProps = {
+  firstQuestion: true,
+};
+
 TextInput.propTypes = {
   activeId: PropTypes.string,
+  firstQuestion: PropTypes.bool,
+  questionNumber: PropTypes.number,
   question: PropTypes.object,
   focusCallback: PropTypes.func,
   answerHandler: PropTypes.func,

--- a/src/components/qas/styles.module.scss
+++ b/src/components/qas/styles.module.scss
@@ -13,3 +13,9 @@
     box-shadow: none;
   }
 }
+
+.label-with-number {
+  p:first-child() {
+    display: inline;
+  }
+}

--- a/src/containers/PageContainer.jsx
+++ b/src/containers/PageContainer.jsx
@@ -17,11 +17,22 @@ class PageContainer extends React.PureComponent {
       TwoCol,
       SingleCol,
     };
+
+    this.state = {
+      questions: null,
+    };
   }
 
   componentDidMount() {
     const { data } = this.props;
-    const { id } = data.allPagesJson.nodes[0];
+    const { id, questionsByPage: questions } = data.allPagesJson.nodes[0];
+    const { questionNumbersByPage } = this.global || {};
+    const questionNumbers = questionNumbersByPage[id];
+
+    this.setState(prevState => ({
+      ...prevState,
+      questions: this.getQuestionsWithNumbers(questionNumbers, questions),
+    }));
 
     this.dispatch.updatePageId(id);
   }
@@ -46,6 +57,16 @@ class PageContainer extends React.PureComponent {
     return contents;
   }
 
+  getQuestionsWithNumbers = (questionNumbers, questions) => {
+    if (!questions || !questionNumbers) return [];
+
+    questions.forEach((question, index) => {
+      question.number = questionNumbers[index];
+    });
+
+    return questions;
+  };
+
   render() {
     const {
       data,
@@ -57,6 +78,8 @@ class PageContainer extends React.PureComponent {
       setActiveQuestion,
       pageContext,
     } = this.props;
+
+    const { questions } = this.state;
 
     const {
       id,
@@ -70,7 +93,6 @@ class PageContainer extends React.PureComponent {
       widgets,
       images,
       tables,
-      questionsByPage: questions,
     } = data.allPagesJson.nodes[0];
     const { env } = pageContext || {};
     const Tag = this.layouts[layout || 'default'];
@@ -96,9 +118,9 @@ class PageContainer extends React.PureComponent {
             widgets,
             tables,
             images,
-            questions,
             answers,
             shared,
+            questions,
           }}
         />
         <PageNav

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -66,6 +66,29 @@ class Layout extends React.Component {
     );
   }
 
+  getQuestionNumbersByPage() {
+    const { pages } = this.state;
+    const qsByPage = {};
+    let qNum = 0;
+
+    // eslint-disable-next-line consistent-return
+    pages.forEach(page => {
+      const { questionsByPage: questions, id } = page;
+
+      if (questions) {
+        qsByPage[id] = questions.map(() => {
+          qNum += 1;
+
+          return qNum;
+        });
+      } else {
+        qsByPage[id] = [];
+      }
+    });
+
+    return qsByPage;
+  }
+
   getTotalQAsByPage() {
     const { pages } = this.state;
     const total = {};
@@ -74,6 +97,7 @@ class Layout extends React.Component {
       const { questionsByPage, id } = page;
 
       const qIds = questionsByPage ? this.getQIds(questionsByPage) : [];
+
       total[id] = {
         questions: qIds,
         answers: [],
@@ -93,6 +117,7 @@ class Layout extends React.Component {
       totalPages: this.getTotalPages(),
       totalQAsByInvestigation: this.getTotalQAs(),
       totalQAsByPage: this.getTotalQAsByPage(),
+      questionNumbersByPage: this.getQuestionNumbersByPage(),
     };
   }
 

--- a/src/state/GlobalStore.js
+++ b/src/state/GlobalStore.js
@@ -7,7 +7,7 @@ class GlobalStore {
   constructor(initialGlobals) {
     this.emptyState = {
       investigation: null,
-      questions: null,
+      // questions: null,
       answers: {},
       pageId: null,
       activeQuestionId: null,
@@ -19,6 +19,7 @@ class GlobalStore {
       visitedPages: [],
       totalQAsByInvestigation: null,
       totalQAsByPage: null,
+      questionNumbersByPage: null,
       ...initialGlobals,
     };
     const { investigation } = this.emptyState;


### PR DESCRIPTION
When getting total qas on page, set questions numbers by page
Use stored qa number in global store to populate question number
Format and catch all breaking layouts within labels to have number sit
  next to first line in label