### PR TITLE
[EPO-3122] OrbitViewer supports Observation points

### DIFF
--- a/src/components/visualizations/orbitalViewer/Observation.jsx
+++ b/src/components/visualizations/orbitalViewer/Observation.jsx
@@ -1,0 +1,72 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { HTML } from 'drei';
+
+import {
+  obsLabel,
+  obsActive,
+  obsHover,
+  obsAnswer,
+  obsMesh,
+} from './orbital-viewer.module.scss';
+
+function Observation({ data, activeObs, vector, selectionCallback }) {
+  const { id, label, interactable, isActive } = data;
+  const [isHover, setIsHover] = useState(false);
+  const [isActiveAnswer, setIsActiveAnswer] = useState(() => {
+    const { id: activeObsId } = activeObs || {};
+    return activeObsId === id;
+  });
+
+  useEffect(() => {
+    const { id: activeObsId } = activeObs || {};
+    setIsActiveAnswer(activeObsId === id);
+  }, [activeObs]);
+
+  function getObsColor() {
+    if (isActive && isActiveAnswer) return 'green';
+    if (isActiveAnswer || isHover) return 'blue';
+
+    return 'gray';
+  }
+
+  return (
+    <mesh
+      className={obsMesh}
+      position={vector}
+      onClick={interactable ? () => selectionCallback(data, 'obs') : null}
+      onPointerOver={() => setIsHover(true)}
+      onPointerOut={() => setIsHover(false)}
+    >
+      <HTML>
+        <div
+          className={classnames(obsLabel, {
+            [obsAnswer]: isActive && isActiveAnswer,
+            [obsHover]: isHover,
+            [obsActive]: isActiveAnswer,
+          })}
+        >
+          {label}
+        </div>
+      </HTML>
+      <octahedronBufferGeometry
+        attach="geometry"
+        args={[isActiveAnswer || isHover ? 35 : 25]}
+      />
+      <meshBasicMaterial
+        attach="material"
+        color={getObsColor(isActiveAnswer, isActive)}
+      />
+    </mesh>
+  );
+}
+
+Observation.propTypes = {
+  data: PropTypes.object,
+  selectionCallback: PropTypes.func,
+  activeObs: PropTypes.object,
+  vector: PropTypes.object,
+};
+
+export default Observation;

--- a/src/components/visualizations/orbitalViewer/Observations.jsx
+++ b/src/components/visualizations/orbitalViewer/Observations.jsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import * as THREE from 'three';
+import Observation from './Observation.jsx';
+import { getMean } from '../../../lib/utilities.js';
+import {
+  getMinorAxis,
+  auToUnit,
+  getFocus,
+  getCurve,
+  convert2dTo3d,
+} from './orbitalUtilities.js';
+
+const Observations = ({ data, observations, activeObs, selectionCallback }) => {
+  const [observationsVectors] = useState(() => {
+    const a = getMean(data, 'a');
+    const e = getMean(data, 'e');
+    const i = getMean(data, 'i');
+    const Peri = getMean(data, 'Peri');
+    const Node = getMean(data, 'Node');
+
+    const meanMajAxis = auToUnit(a);
+    const meanMinAxis = getMinorAxis(a, e);
+    const focus = getFocus(meanMajAxis, meanMinAxis);
+    const offsetCenter = new THREE.Vector3(focus, 0, 0);
+    const curve = getCurve(
+      meanMajAxis,
+      meanMinAxis,
+      offsetCenter.x,
+      offsetCenter.y
+    );
+
+    return (observations || []).map(obs => {
+      const { position } = obs;
+      return convert2dTo3d(curve.getPoint(position), { a, e, i, Peri, Node });
+    });
+  });
+
+  return (
+    <>
+      {observationsVectors && (
+        <>
+          {observationsVectors.map((obsVector, i) => {
+            const observation = observations[i];
+            const { id } = observation;
+
+            return (
+              <Observation
+                key={id}
+                data={observation}
+                vector={obsVector}
+                {...{ selectionCallback, activeObs }}
+              />
+            );
+          })}
+        </>
+      )}
+    </>
+  );
+};
+
+Observations.propTypes = {
+  data: PropTypes.array,
+  observations: PropTypes.array,
+  selectionCallback: PropTypes.func,
+  activeObs: PropTypes.object,
+};
+
+export default Observations;

--- a/src/components/visualizations/orbitalViewer/Orbital.jsx
+++ b/src/components/visualizations/orbitalViewer/Orbital.jsx
@@ -203,7 +203,10 @@ const Orbital = ({
           />
         </line>
         {/* Orbital Object */}
-        <mesh position={point.position} onClick={() => selectionCallback(data)}>
+        <mesh
+          position={point.position}
+          onClick={() => selectionCallback(data, 'neo')}
+        >
           <HTML>
             <div
               className={label}

--- a/src/components/visualizations/orbitalViewer/Orbitals.jsx
+++ b/src/components/visualizations/orbitalViewer/Orbitals.jsx
@@ -8,6 +8,7 @@ import { earth, jupiter, neptune } from './orbitalUtilities.js';
 function Orbitals({
   neos,
   activeNeo,
+  activeObs,
   selectionCallback,
   activeVelocityCallback,
   playing,
@@ -17,6 +18,7 @@ function Orbitals({
   includeRefObjs,
   defaultZoom,
   potentialOrbits,
+  observations,
 }) {
   function reducer(state) {
     const { remainingInits } = state;
@@ -84,6 +86,8 @@ function Orbitals({
             frameOverride,
             selectionCallback,
             activeVelocityCallback,
+            observations,
+            activeObs,
           }}
           initCallback={dispatch}
         />
@@ -119,6 +123,7 @@ function Orbitals({
 Orbitals.propTypes = {
   neos: PropTypes.array,
   activeNeo: PropTypes.object,
+  activeObs: PropTypes.object,
   selectionCallback: PropTypes.func,
   playing: PropTypes.bool,
   dayPerVizSec: PropTypes.number,
@@ -128,6 +133,7 @@ Orbitals.propTypes = {
   activeVelocityCallback: PropTypes.func,
   defaultZoom: PropTypes.number,
   potentialOrbits: PropTypes.bool,
+  observations: PropTypes.array,
 };
 
 export default Orbitals;

--- a/src/components/visualizations/orbitalViewer/PotentialOrbits.jsx
+++ b/src/components/visualizations/orbitalViewer/PotentialOrbits.jsx
@@ -1,29 +1,21 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import * as THREE from 'three';
+import Observations from './Observations.jsx';
 import {
   getMinorAxis,
   auToUnit,
-  degsToRads,
   getFocus,
   getCurve,
+  convert2dTo3d,
 } from './orbitalUtilities.js';
 
-const PotentialOrbits = ({ data }) => {
-  function convert2dTo3d(vector2D, orbitData) {
-    const { i, Peri: peri, Node: ascendingNode } = orbitData;
-    const yAxisOfRotation = new THREE.Vector3(0, 1, 0);
-    const zAxisOfRotation = new THREE.Vector3(0, 0, 1);
-
-    return new THREE.Vector3(vector2D.x, vector2D.y, 0)
-      .applyAxisAngle(zAxisOfRotation, peri ? degsToRads(peri + 90) : 0)
-      .applyAxisAngle(yAxisOfRotation, degsToRads(i))
-      .applyAxisAngle(
-        zAxisOfRotation,
-        ascendingNode ? degsToRads(ascendingNode) : 0
-      );
-  }
-
+const PotentialOrbits = ({
+  data,
+  observations,
+  activeObs,
+  selectionCallback,
+}) => {
   function getCurveVectors(majAxis, minAxis, orbitData) {
     const focus = getFocus(majAxis, minAxis);
     const offsetCenter = new THREE.Vector3(focus, 0, 0);
@@ -79,14 +71,24 @@ const PotentialOrbits = ({ data }) => {
   });
 
   return (
-    <lineSegments position={[0, 0, 0]} geometry={potentialsGeometry}>
-      <lineBasicMaterial attach="material" color="pink" />
-    </lineSegments>
+    <>
+      <lineSegments position={[0, 0, 0]} geometry={potentialsGeometry}>
+        <lineBasicMaterial attach="material" color="pink" />
+      </lineSegments>
+      {observations && (
+        <Observations
+          {...{ data, observations, selectionCallback, activeObs }}
+        />
+      )}
+    </>
   );
 };
 
 PotentialOrbits.propTypes = {
   data: PropTypes.array,
+  observations: PropTypes.array,
+  selectionCallback: PropTypes.func,
+  activeObs: PropTypes.object,
 };
 
 export default PotentialOrbits;

--- a/src/components/visualizations/orbitalViewer/index.jsx
+++ b/src/components/visualizations/orbitalViewer/index.jsx
@@ -14,11 +14,13 @@ import { container, orbitalCanvas } from './orbital-viewer.module.scss';
 function OrbitalViewer({
   neos,
   activeNeo,
-  updateActiveNeo,
+  activeObs,
+  selectionCallback,
   paused,
   pov,
   defaultZoom,
   potentialOrbits,
+  observations,
 }) {
   const speeds = [0.00001157, 1.1574, 11.574, 30, 365.25]; // [realtime, 100,000 X, 1,000,000 X, 2.592e+6 X, 3.154e+7 X]
 
@@ -74,18 +76,20 @@ function OrbitalViewer({
           />
           <ambientLight intensity={0.9} />
           <Orbitals
-            potentialOrbits={potentialOrbits}
             includeRefObjs
-            selectionCallback={updateActiveNeo}
             activeVelocityCallback={setActiveVelocity}
             {...{
               defaultZoom,
               neos,
               activeNeo,
+              activeObs,
               playing,
               stepDirection,
               dayPerVizSec,
               frameOverride,
+              potentialOrbits,
+              observations,
+              selectionCallback,
             }}
           />
           <mesh position={[0, 0, 0]}>
@@ -118,11 +122,13 @@ OrbitalViewer.defaultProps = {
 OrbitalViewer.propTypes = {
   neos: PropTypes.array,
   activeNeo: PropTypes.object,
-  updateActiveNeo: PropTypes.func,
+  activeObs: PropTypes.object,
+  selectionCallback: PropTypes.func,
   paused: PropTypes.bool,
   pov: PropTypes.string,
   defaultZoom: PropTypes.number,
   potentialOrbits: PropTypes.bool,
+  observations: PropTypes.array,
 };
 
 export default OrbitalViewer;

--- a/src/components/visualizations/orbitalViewer/orbital-viewer.module.scss
+++ b/src/components/visualizations/orbitalViewer/orbital-viewer.module.scss
@@ -86,6 +86,27 @@
   color: $white;
 }
 
+.obs-mesh {
+  cursor: pointer;
+}
+
+.obs-label {
+  padding-top: 8px;
+  font-size: 16px;
+  color: $white;
+  cursor: pointer;
+
+  &.obs-answer, &.obs-hover {
+    font-size: 18px;
+    color: 'blue';
+  }
+
+  &.obs-active {
+    font-size: 18px;
+    color: 'red';
+  }
+}
+
 .details {
   position: absolute;
   top: 0;

--- a/src/components/visualizations/orbitalViewer/orbitalUtilities.js
+++ b/src/components/visualizations/orbitalViewer/orbitalUtilities.js
@@ -121,3 +121,17 @@ export const getRadius = magnitude => {
 
   return adjustedRadius;
 };
+
+export const convert2dTo3d = (vector2D, orbitData) => {
+  const { i, Peri: peri, Node: ascendingNode } = orbitData;
+  const yAxisOfRotation = new THREE.Vector3(0, 1, 0);
+  const zAxisOfRotation = new THREE.Vector3(0, 0, 1);
+
+  return new THREE.Vector3(vector2D.x, vector2D.y, 0)
+    .applyAxisAngle(zAxisOfRotation, peri ? degsToRads(peri + 90) : 0)
+    .applyAxisAngle(yAxisOfRotation, degsToRads(i))
+    .applyAxisAngle(
+      zAxisOfRotation,
+      ascendingNode ? degsToRads(ascendingNode) : 0
+    );
+};

--- a/src/containers/WithQAing.jsx
+++ b/src/containers/WithQAing.jsx
@@ -31,6 +31,7 @@ export const WithQAing = ComposedComponent => {
         galaxies: this.getGalaxiesContent,
         supernova: this.getSupernovaContent,
         hubblePlot: this.getHubblePlotContent,
+        observation: this.getObservationContent,
       };
     }
 
@@ -206,6 +207,10 @@ export const WithQAing = ComposedComponent => {
 
     getNeoContent(data) {
       return data.name;
+    }
+
+    getObservationContent(data) {
+      return data.label;
     }
 
     getContent(answerAccessor, data) {

--- a/src/data/pages/determining-orbits-4.json
+++ b/src/data/pages/determining-orbits-4.json
@@ -20,7 +20,13 @@
       "source": "/data/neos/test1_orb_1-20.json",
       "options": {
         "defaultZoom": 0.5,
-        "potentialOrbits": true
+        "potentialOrbits": true,
+        "questionId": "17",
+        "observations":[
+          {"id": "obs-1", "label": "A","interactable": true, "isActive": false, "position": 0.25},
+          {"id": "obs-2", "label": "B","interactable": true, "isActive": true, "position": 0.35},
+          {"id": "obs-3", "label": "C","interactable": true, "isActive": false, "position": 0.5}
+        ]
       }
     }
   ],
@@ -44,8 +50,8 @@
           "tool": "selection",
           "title": "Question #1",
           "label": "<p>Try clicking on locations (A, B, C, D) until you successfully observe the asteroid.</p>",
-          "answerPre": "<span>Selected Asteroid: </span>",
-          "answerAccessor": "orbit"
+          "answerPre": "<span>Selected Observation: </span>",
+          "answerAccessor": "observation"
         }
       ]
     },

--- a/src/fragments/widget.js
+++ b/src/fragments/widget.js
@@ -10,7 +10,7 @@ export const nestedWidgetFragment = graphql`
   }
 `;
 
-export const widgetFragemnt = graphql`
+export const widgetFragment = graphql`
   fragment Widget on PagesJsonWidgets {
     type
     source

--- a/src/fragments/widgetOptions.js
+++ b/src/fragments/widgetOptions.js
@@ -1,6 +1,6 @@
 import { graphql } from 'gatsby';
 
-export const nestedWidgetOptionsFragemnt = graphql`
+export const nestedWidgetOptionsFragment = graphql`
   fragment NestedWidgetOptions on PagesJsonWidgetsWidgetsOptions {
     title
     domain
@@ -13,7 +13,7 @@ export const nestedWidgetOptionsFragemnt = graphql`
   }
 `;
 
-export const widgetOptionsFragemnt = graphql`
+export const widgetOptionsFragment = graphql`
   fragment WidgetOptions on PagesJsonWidgetsOptions {
     title
     showSelector
@@ -48,5 +48,12 @@ export const widgetOptionsFragemnt = graphql`
     galaxyImg
     questionId
     potentialOrbits
+    observations {
+      id
+      label
+      interactable
+      isActive
+      position
+    }
   }
 `;


### PR DESCRIPTION
Observation points are clickable and produce answers;
Style changes on hover and click, and in presence of correct selection;
Observations points positions are defined in relation to the mean curve when averaging potential orbits data (i.e. can only be used in conjunction with the potential orbits);