### PR TITLE
[B] All calls to updateAnswer include appropriate 'type' param

### DIFF
--- a/src/components/charts/galaxySelector/Point.jsx
+++ b/src/components/charts/galaxySelector/Point.jsx
@@ -87,7 +87,6 @@ class Point extends React.PureComponent {
         r={this.getRadius(id, radius)}
         fill="transparent"
         stroke={this.getStroke(isActive, isSelected, color)}
-        strokeWidth={0}
       />
     );
   }

--- a/src/components/charts/galaxySelector/Points.jsx
+++ b/src/components/charts/galaxySelector/Points.jsx
@@ -36,7 +36,7 @@ class Points extends React.PureComponent {
               classes={pointClasses}
               x={xScale(xVal)}
               y={yScale(d[yValueAccessor])}
-              color={isNumber(color) ? chartColors.chart7 : color}
+              color={isNumber(color) ? chartColors.chart6 : color}
               tabIndex="0"
             />
           );

--- a/src/containers/AstroToolContainer.jsx
+++ b/src/containers/AstroToolContainer.jsx
@@ -58,11 +58,11 @@ class AstroToolContainer extends React.PureComponent {
     const answer = answers[activeQuestionId || questionId];
 
     if (isEmpty(answer) && activeQuestionId === questionId) {
-      this.updateAnswer();
+      this.getInitialAnswer();
     }
   }
 
-  updateAnswer = () => {
+  getInitialAnswer = () => {
     const { widget } = this.props;
     const { options } = widget;
     const { objectName } = options || {};
@@ -93,7 +93,7 @@ class AstroToolContainer extends React.PureComponent {
           const { options: opt } = w || {};
           const { questionId } = opt || {};
           const { selectedData: newData } = this.state;
-          updateAnswer(questionId, newData);
+          updateAnswer(questionId, newData, 'change');
         }
       );
     }
@@ -107,7 +107,7 @@ class AstroToolContainer extends React.PureComponent {
     if (!d) return;
 
     if (questionId) {
-      updateAnswer(questionId, d);
+      updateAnswer(questionId, d, 'change');
       this.setState(prevState => ({
         ...prevState,
         selectedData: d,

--- a/src/containers/GalaxiesFilterSelectorContainer.jsx
+++ b/src/containers/GalaxiesFilterSelectorContainer.jsx
@@ -132,7 +132,7 @@ class GalaxiesFilterSelectorContainer extends React.PureComponent {
       const answer = answers[qId];
       const answerObj = !isEmpty(answer) ? { ...answer.data, ...dObj } : dObj;
 
-      updateAnswer(qId, answerObj);
+      updateAnswer(qId, answerObj, 'change');
     }
   };
 

--- a/src/containers/GalaxiesSelectorContainer.jsx
+++ b/src/containers/GalaxiesSelectorContainer.jsx
@@ -125,7 +125,7 @@ class GalaxiesSelectorContainer extends React.PureComponent {
     const { toggleDataPointsVisibility: qId } = options || {};
 
     if (qId && isArray(allSelected)) {
-      updateAnswer(qId, allSelected);
+      updateAnswer(qId, allSelected, 'change');
     }
 
     this.updateActiveGalaxy(selection);

--- a/src/containers/GalaxyScramblerContainer.jsx
+++ b/src/containers/GalaxyScramblerContainer.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import isEmpty from 'lodash/isEmpty';
 import find from 'lodash/find';
 import classnames from 'classnames';
 import API from '../lib/API.js';
@@ -65,28 +64,6 @@ class GalaxyScramblerContainer extends React.PureComponent {
       navItems: this.generateNavItems(scrambles, activeScramble),
     }));
   };
-
-  userHubblePlotCallback = (qId, data) => {
-    const { updateAnswer } = this.props;
-
-    updateAnswer(qId, data);
-
-    this.setState(prevState => ({
-      ...prevState,
-      data,
-    }));
-  };
-
-  getHubbleConstant(qId) {
-    const { answers } = this.props;
-    const answer = answers[qId];
-
-    if (!isEmpty(answer)) {
-      return answer.data;
-    }
-
-    return null;
-  }
 
   generateNavItems(scrambles, activeScramble) {
     return scrambles.map((scramble, i) => {

--- a/src/containers/GalaxySelectorContainer.jsx
+++ b/src/containers/GalaxySelectorContainer.jsx
@@ -246,7 +246,7 @@ class GalaxySelectorContainer extends React.PureComponent {
       const answer = answers[qId];
       const answerObj = !isEmpty(answer) ? { ...answer.data, ...dObj } : dObj;
 
-      updateAnswer(qId, answerObj);
+      updateAnswer(qId, answerObj, 'change');
     }
 
     if (d.length > 1) {
@@ -264,7 +264,7 @@ class GalaxySelectorContainer extends React.PureComponent {
   userHubblePlotCallback = (qId, plottedData) => {
     const { updateAnswer } = this.props;
 
-    updateAnswer(qId, plottedData);
+    updateAnswer(qId, plottedData, 'change');
 
     this.setState(prevState => ({
       ...prevState,

--- a/src/containers/HubblePlotContainer.jsx
+++ b/src/containers/HubblePlotContainer.jsx
@@ -38,7 +38,7 @@ class HubblePlotContainer extends React.PureComponent {
   userHubblePlotCallback = (qId, data) => {
     const { updateAnswer, activeQuestionId } = this.props;
 
-    updateAnswer(qId || activeQuestionId, data);
+    updateAnswer(qId || activeQuestionId, data, 'change');
 
     this.setState(prevState => ({
       ...prevState,
@@ -48,7 +48,7 @@ class HubblePlotContainer extends React.PureComponent {
 
   userTrendlineCallback = (qId, data) => {
     const { updateAnswer, activeQuestionId } = this.props;
-    updateAnswer(qId || activeQuestionId, data);
+    updateAnswer(qId || activeQuestionId, data, 'change');
   };
 
   getHubbleConstant(qId, hubbleConstant) {

--- a/src/containers/OrbitalViewerContainer.jsx
+++ b/src/containers/OrbitalViewerContainer.jsx
@@ -142,7 +142,7 @@ class OrbitalViewerContainer extends React.PureComponent {
     const { questionId } = options || {};
 
     if (questionId) {
-      updateAnswer(questionId, data);
+      updateAnswer(questionId, data, 'change');
     }
   }
 

--- a/src/containers/PrismWidgetContainer.jsx
+++ b/src/containers/PrismWidgetContainer.jsx
@@ -3,59 +3,38 @@ import PropTypes from 'prop-types';
 import PrismWidget from '../components/charts/prismWidget/index.jsx';
 
 class PrismWidgetContainer extends React.PureComponent {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      selectedColor: null,
-    };
-  }
-
-  componentDidMount() {
-    const { widget } = this.props;
+  getSelectedColor() {
+    const { widget, answers } = this.props;
     const { options } = widget;
     const { questionId } = options || {};
-    const { answers } = this.props;
     const answer = answers[questionId];
-    const { data: answerData } = answer || {};
 
-    this.setState(prevState => ({
-      ...prevState,
-      selectedColor: answerData || 'None',
-    }));
+    return answer ? answer.data : 'None';
   }
 
   selectionCallback = value => {
-    const { widget } = this.props;
+    if (!value) return;
+    const { widget, updateAnswer } = this.props;
     const { options } = widget;
     const { questionId } = options || {};
-    const { updateAnswer } = this.props;
-    if (!value) return;
 
     if (questionId) {
-      updateAnswer(questionId, value);
-      this.setState(prevState => ({
-        ...prevState,
-        selectedColor: value,
-      }));
+      updateAnswer(questionId, value, 'change');
     }
   };
 
   render() {
-    const { selectedColor } = this.state;
     const { widget } = this.props;
     const {
       options: { questionId },
     } = widget || {};
 
     return (
-      selectedColor && (
-        <PrismWidget
-          selectedColor={selectedColor}
-          hasQuestionId={questionId !== null}
-          selectionCallback={this.selectionCallback}
-        />
-      )
+      <PrismWidget
+        selectedColor={this.getSelectedColor()}
+        hasQuestionId={questionId !== null}
+        selectionCallback={this.selectionCallback}
+      />
     );
   }
 }

--- a/src/containers/SupernovaSelectorWithLightCurveContainer.jsx
+++ b/src/containers/SupernovaSelectorWithLightCurveContainer.jsx
@@ -98,7 +98,7 @@ class SupernovaSelectorWithLightCurveContainer extends React.PureComponent {
       const answer = answers[qId];
       const answerObj = !isEmpty(answer) ? { ...answer.data, ...dObj } : dObj;
 
-      updateAnswer(qId, answerObj);
+      updateAnswer(qId, answerObj, 'change');
     }
 
     if (d.length >= 1) {

--- a/src/containers/TimeDomainViewerContainer.jsx
+++ b/src/containers/TimeDomainViewerContainer.jsx
@@ -85,7 +85,7 @@ class TimeDomainViewerContainer extends React.PureComponent {
     const qId = toggleDataPointsVisibility || activeQuestionId;
     const answerData = this.getSelectionAnswerData();
 
-    if (!answerData) updateAnswer(qId, data);
+    if (!answerData) updateAnswer(qId, data, 'change');
   };
 
   onBlinkChange = update => {


### PR DESCRIPTION
updateAnswer is an alias for the answer handler func in GlobalStore;
This update ensures all calls to this func in widgets and various question
types include a string ref to indicate type (options are null, 'focus', 'blur', 'change');
Crucially, using non-null values where appropriate in order to trigger update to activeQuestion in global store