### PR TITLE
[EPO-4341] Remove the grid, axes, and coordinate numbers in 3D Widget

### DIFF
--- a/src/components/charts/galaxiesPosition3D/index.jsx
+++ b/src/components/charts/galaxiesPosition3D/index.jsx
@@ -35,6 +35,7 @@ class GalaxiesPosition3D extends React.PureComponent {
 
     return {
       grid3D: {
+        show: false,
         bottom: '20%',
         viewControl: {
           projection: 'perspective',


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4341

## What this change does ##

Did some digging within the provided examples here at this website, and found this example where I was able to change the `show: true` parameter to `false` and _viola!_

Applied what I learned and removed the grid, axes, and coordinate numbers with this simple little param designated by:
```
grid3D: {
  show: false, <--- this little guy here
  bottom: ...
...
}
```
Next step in the 3D Widget's evolution!!!!

## Notes for reviewers ##

This change can be found in the ../components/galaxiesPosition3D/index.jsx file at /expanding-universe/testing-law/ of the Expanding investigation.

Include an indication of how detailed a review you want on a 1-10 scale.
- 1 = "I barely need review on this"
- 5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"
- 10 = "I think it works, I can explain how, but only over screenshare"
**Level 3 requested review**

## Testing ##


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [X] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
![image](https://user-images.githubusercontent.com/8799443/108564567-8e341f80-72c0-11eb-9813-a3bf34267aa9.png)

### After:
![image](https://user-images.githubusercontent.com/8799443/108564527-7ceb1300-72c0-11eb-88e9-226ce1c56c6a.png)
