### PR TITLE
[EPO-4342] Add connecting lines from MW to each galaxy

### DIFF
--- a/src/components/charts/galaxiesPosition3D/index.jsx
+++ b/src/components/charts/galaxiesPosition3D/index.jsx
@@ -30,8 +30,27 @@ class GalaxiesPosition3D extends React.PureComponent {
     });
   }
 
+  arrayifyLabelsDataPoints(data) {
+    return [data.x, data.y, data.z];
+  }
+
   getOption(data) {
     const [labels, noLabels] = partition(data, o => o.label);
+
+    const connectingLines = noLabels.map(datum => {
+      return {
+        type: 'line3D',
+        data: [
+          this.arrayifyLabelsDataPoints(labels[0]),
+          this.arrayifyLabelsDataPoints(datum),
+        ],
+        lineStyle: {
+          color: '#000',
+          opacity: 0.3,
+          width: 1.5,
+        },
+      };
+    });
 
     return {
       grid3D: {
@@ -65,7 +84,7 @@ class GalaxiesPosition3D extends React.PureComponent {
           name: 'Labeled Data',
           animation: false,
           data: this.arrayifyLabelsData(labels),
-          symbolSize: 10,
+          symbolSize: 20,
           itemStyle: {
             color: params => {
               return params.data[4];
@@ -83,6 +102,7 @@ class GalaxiesPosition3D extends React.PureComponent {
             },
           },
         },
+        ...connectingLines,
       ],
     };
   }


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4342

## What this change does ##

Add connecting lines from the Milky Way galaxy to each individual galaxy. 
In order to create a line for each connection individually, I had to build an array of objects and spread them into the series array.

## Notes for reviewers ##

Updates can be found in the `/components/charts/galaxiesPosition3D/index.jsx`

Include an indication of how detailed a review you want on a 1-10 scale.
- 1 = "I barely need review on this"
- 5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"
- 10 = "I think it works, I can explain how, but only over screen share"

**Requesting a level 5 review**

## Testing ##

Visually ? :) 


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
![image](https://user-images.githubusercontent.com/8799443/109077174-fcaa2080-76b8-11eb-8696-425576b702dc.png)

### After:
![image](https://user-images.githubusercontent.com/8799443/109076659-29aa0380-76b8-11eb-9933-ea33736d953d.png)
