### PR TITLE
[EPO-4340] Add grid lines to hubble plot

### DIFF
--- a/src/assets/stylesheets/_variables.scss
+++ b/src/assets/stylesheets/_variables.scss
@@ -19,6 +19,7 @@ $neutral10: #f3f3f3;
 $neutral20: #737373;
 $neutral30: #828287;
 $neutral40: #525459;
+$neutral50: #c2c2c2;
 
 $basePrimary: $ral5018HR;
 $baseSecondaryLight: $lightBlue;

--- a/src/components/charts/hubblePlot/AxisGrid.jsx
+++ b/src/components/charts/hubblePlot/AxisGrid.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { select as d3Select } from 'd3-selection';
+import { axisBottom as d3AxisBottom, axisLeft as d3AxisLeft } from 'd3-axis';
+import { axisGrid } from './hubble-plot.module.scss';
+
+class AxisGrid extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.yAxisGridContainer = React.createRef();
+    this.xAxisGridContainer = React.createRef();
+  }
+
+  componentDidMount() {
+    this.updateAxis();
+  }
+
+  componentDidUpdate() {
+    this.updateAxis();
+  }
+
+  updateAxis() {
+    const {
+      xScale,
+      yScale,
+      height,
+      width,
+      xNumGridLines,
+      yNumGridLines,
+    } = this.props;
+
+    const yAxisGrid = d3AxisLeft(yScale)
+      .tickSize(-width)
+      .tickFormat('')
+      .ticks(yNumGridLines);
+    const xAxisGrid = d3AxisBottom(xScale)
+      .tickSize(-height)
+      .tickFormat('')
+      .ticks(xNumGridLines);
+
+    const $yAxisGrid = d3Select(this.yAxisGridContainer.current);
+    const $xAxisGrid = d3Select(this.xAxisGridContainer.current);
+
+    $yAxisGrid.call(yAxisGrid);
+    $xAxisGrid.call(xAxisGrid);
+  }
+
+  render() {
+    const { height, padding, offsetTop } = this.props;
+
+    return (
+      <>
+        <g
+          key="y-axis-grid"
+          className={`y-axis-grid ${axisGrid}`}
+          transform={`translate(${padding}, ${offsetTop})`}
+          ref={this.yAxisGridContainer}
+        />
+        <g
+          key="x-axis-grid"
+          className={`x-axis-grid ${axisGrid}`}
+          transform={`translate(0, ${height - padding + offsetTop})`}
+          ref={this.xAxisGridContainer}
+        />
+      </>
+    );
+  }
+}
+
+AxisGrid.propTypes = {
+  height: PropTypes.number,
+  width: PropTypes.number,
+  xNumGridLines: PropTypes.number,
+  yNumGridLines: PropTypes.number,
+  padding: PropTypes.number,
+  offsetTop: PropTypes.number,
+  xScale: PropTypes.any,
+  yScale: PropTypes.any,
+};
+
+export default AxisGrid;

--- a/src/components/charts/hubblePlot/XAxis.jsx
+++ b/src/components/charts/hubblePlot/XAxis.jsx
@@ -41,7 +41,7 @@ class XAxis extends React.PureComponent {
       <>
         <g
           key="x-axis"
-          className="x-axis axis"
+          className={`x-axis axis ${styles.axis}`}
           transform={`translate(0, ${height - padding + offsetTop})`}
           ref={this.xAxisContainer}
         />

--- a/src/components/charts/hubblePlot/YAxis.jsx
+++ b/src/components/charts/hubblePlot/YAxis.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { select as d3Select } from 'd3-selection';
 import { axisLeft as d3AxisLeft } from 'd3-axis';
+import { axis } from './hubble-plot.module.scss';
 
 class YAxis extends React.PureComponent {
   constructor(props) {
@@ -33,7 +34,7 @@ class YAxis extends React.PureComponent {
       <>
         <g
           key="y-axis"
-          className="y-axis axis"
+          className={`y-axis ${axis}`}
           transform={`translate(${padding}, ${offsetTop})`}
           ref={this.yAxisContainer}
         />

--- a/src/components/charts/hubblePlot/hubble-plot.module.scss
+++ b/src/components/charts/hubblePlot/hubble-plot.module.scss
@@ -12,6 +12,18 @@
   // }
 }
 
+.axis {
+  :global .tick {
+    @include labelPrimary;
+  }
+}
+
+.axis-grid {
+  :global line {
+    stroke: $neutral50;
+  }
+}
+
 .widget-title {
   margin-left: 20px;
   text-align: center;

--- a/src/components/charts/hubblePlot/index.jsx
+++ b/src/components/charts/hubblePlot/index.jsx
@@ -18,6 +18,7 @@ import { arrayify } from '../../../lib/utilities.js';
 import Trendline from './Trendline.jsx';
 import Points from './Points';
 import CursorPoint from './CursorPoint.jsx';
+import AxisGrid from './AxisGrid.jsx';
 import XAxis from './XAxis.jsx';
 import YAxis from './YAxis.jsx';
 import Tooltip from '../shared/Tooltip.jsx';
@@ -439,6 +440,17 @@ class HubblePlot extends React.Component {
               />
             </clipPath>
           </defs>
+          <AxisGrid
+            {...{
+              height,
+              width,
+              xScale,
+              yScale,
+              padding,
+              offsetTop,
+              offsetRight,
+            }}
+          />
           <XAxis
             label={xAxisLabel}
             scale={xScale}
@@ -540,7 +552,7 @@ HubblePlot.defaultProps = {
   xValueAccessor: 'distance',
   yValueAccessor: 'velocity',
   xAxisLabel: 'Distance (Mpc)',
-  yAxisLabel: 'Velocity (Km/s)',
+  yAxisLabel: 'Velocity (km/s)',
   tooltipAccessors: ['name', 'distance', 'velocity'],
   tooltipLabels: ['Galaxy', 'Distance', 'Velocity'],
   isVisible: true,


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4340

## What this change does ##

Add grind line to hubble plot by creating a new component that builds the svg based off the tick lines.. Component allows for a specified number of grid lines if needed.

## Notes for reviewers ##

Changes/Additions can be found in `/components/charts/hubblePlot/index.jsx`, `/components/charts/hubblePlot/AxisGrid.jsx`, `/components/charts/hubblePlot/hubble-plot.moduel.scss` and `/assets/stylesheets/_variables.scss`.

Include an indication of how detailed a review you want on a 1-10 scale.
- 1 = "I barely need review on this"
- 5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"
- 10 = "I think it works, I can explain how, but only over screen share"

**Requesting review level 5**

## Testing ##


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
![image](https://user-images.githubusercontent.com/8799443/109080887-8f998980-76be-11eb-95ae-0c903f24d239.png)

### After:
![image](https://user-images.githubusercontent.com/8799443/109080594-1bf77c80-76be-11eb-801a-848f5731d98c.png)
