### PR TITLE
[EPO-4419] Fix lazyloading

### DIFF
--- a/src/components/site/imageLoader/index.jsx
+++ b/src/components/site/imageLoader/index.jsx
@@ -15,21 +15,16 @@ class ImageLoader extends React.PureComponent {
       loaded: false,
     };
 
-    // this.timeFallback = null;
-    // this.setTimeoutFallback();
+    this.timeFallback = setTimeout(this.handleLoading, 4000);
   }
 
-  // componentWillUnmount() {
-  //   clearTimeout(this.timeFallback);
-  // }
-
-  // setTimeoutFallback() {
-  //   this.timeFallback = setTimeout(this.handleLoading, 10000);
-  // }
+  componentWillUnmount() {
+    clearTimeout(this.timeFallback);
+  }
 
   handleLoading = () => {
-    // clearTimeout(this.timeFallback);
     this.setState(() => ({ loaded: true }));
+    clearTimeout(this.timeFallback);
   };
 
   render() {


### PR DESCRIPTION
JIRA: [EPO-4419](https://jira.lsstcorp.org/browse/EPO-4419)
## What this change does ##

Re-implements timeout on lazy-loaded images.  The timeout should ensure that the image becomes visible after 4 secs, even if the `onload` has not fired, even if the image has not finished loading.

## Notes for reviewers ##

This is a change we'll have to keep an eye on on staging due to challenges testing.

1 = "I barely need review on this"

## Testing ##

Tested locally by throttling network in chrome devTools, and on staging by checking when `console.log`s fired in the timeout callback vs the `onload` handler.  Console.logs have since been removed, but can still test on staging by observing when or if images in the investigation load in 4 secs or less.

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [X] This change impacts several investigations (e.g. the change affects reused styles, widgets, pages, QAs, utility methods, etc.)
- [ ] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does
