### PR TITLE
[EPO-4404] Break apart GalaxySelector into new widget

### DIFF
--- a/src/components/widgets/widgets-utilities.js
+++ b/src/components/widgets/widgets-utilities.js
@@ -1,6 +1,7 @@
 import SupernovaSelectorWithLightCurve from '../../containers/SupernovaSelectorWithLightCurveContainer.jsx';
 import GalaxyScrambler from '../../containers/GalaxyScramblerContainer.jsx';
 import GalaxySelector from '../../containers/GalaxySelectorContainer.jsx';
+import GalaxySupernovaSelector from '../../containers/GalaxySupernovaSelectorContainer.jsx';
 import GalaxiesSelector from '../../containers/GalaxiesSelectorContainer.jsx';
 import GalaxiesFilterSelector from '../../containers/GalaxiesFilterSelectorContainer.jsx';
 import HubblePlot from '../../containers/HubblePlotContainer.jsx';
@@ -20,6 +21,7 @@ export const widgetTags = {
   SupernovaSelectorWithLightCurve,
   GalaxyScrambler,
   GalaxySelector,
+  GalaxySupernovaSelector,
   GalaxiesSelector,
   GalaxiesFilterSelector,
   HubblePlot,

--- a/src/containers/GalaxySupernovaSelectorContainer.jsx
+++ b/src/containers/GalaxySupernovaSelectorContainer.jsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import isEmpty from 'lodash/isEmpty';
+import filter from 'lodash/filter';
+import API from '../lib/API.js';
+import GalaxySelector from '../components/charts/galaxySelector';
+import {
+  getSelectedData,
+  getActiveImageIndex,
+  getAlertImages,
+  getGalaxyPointData,
+} from '../components/charts/galaxySelector/galaxySelectorUtilities.js';
+
+class GalaxySupernovaSelectorContainer extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      data: null,
+      selectedData: null,
+      activeGalaxy: null,
+      activeGalaxyPointData: null,
+      activeAlert: null,
+      activeImageIndex: 0,
+      activeImageId: null,
+    };
+  }
+
+  componentDidMount() {
+    const {
+      widget: { source },
+    } = this.props;
+
+    API.get(source).then(response => {
+      const data = response.data.map(galaxy => {
+        galaxy.images = getAlertImages(galaxy.id || galaxy.name, galaxy.alerts);
+        return galaxy;
+      });
+
+      const { options } = this.props;
+      const { preSelectedId } = options || {};
+
+      const selectedGalaxy = filter(data, { id: preSelectedId })[0] || {};
+
+      const { alerts } = selectedGalaxy;
+
+      this.setState(prevState => ({
+        ...prevState,
+        activeAlert: alerts[0],
+        activeGalaxy: selectedGalaxy,
+        activeGalaxyPointData: getGalaxyPointData(selectedGalaxy),
+        data,
+      }));
+    });
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const { options, answers } = this.props;
+    const { toggleDataPointsVisibility: selectorQId } = options || {};
+    const answerSelected = answers[selectorQId];
+    const { activeGalaxy } = this.state;
+    const { answers: prevAnswers } = prevProps;
+    const answerPrevSelected = prevAnswers[selectorQId];
+    const { activeGalaxy: prevActiveGalaxy } = prevState;
+
+    if (
+      activeGalaxy !== prevActiveGalaxy ||
+      answerSelected !== answerPrevSelected
+    ) {
+      this.updateSelectedData(activeGalaxy, answers, selectorQId);
+    }
+  }
+
+  updateSelectedData(activeGalaxy, answers, qId) {
+    this.setState(prevState => ({
+      ...prevState,
+      selectedData: getSelectedData(activeGalaxy, answers, qId),
+    }));
+  }
+
+  selectionCallback = d => {
+    if (!d) return;
+
+    const {
+      answers,
+      updateAnswer,
+      activeQuestionId,
+      options: { toggleDataPointsVisibility },
+    } = this.props;
+    const { activeGalaxy } = this.state;
+    const qId = toggleDataPointsVisibility || activeQuestionId;
+
+    if (qId) {
+      const dObj = { [activeGalaxy.name]: d };
+      const answer = answers[qId];
+      const answerObj = !isEmpty(answer) ? { ...answer.data, ...dObj } : dObj;
+
+      updateAnswer(qId, answerObj, 'change');
+    }
+  };
+
+  onBlinkChange = update => {
+    this.setState(prevState => ({
+      ...prevState,
+      ...update,
+    }));
+  };
+
+  render() {
+    const {
+      activeAlert,
+      activeImageId,
+      activeImageIndex,
+      data,
+      activeGalaxy,
+      activeGalaxyPointData,
+      selectedData,
+    } = this.state;
+
+    const { options } = this.props;
+    const { image, autoplay } = options || {};
+
+    return (
+      <>
+        <h2 className="space-bottom heading-primary">
+          Galaxy & Supernova Selector
+        </h2>
+        {data && (
+          <div className="galaxy-selector-images--container">
+            <GalaxySelector
+              className={`galaxy-selector-${data.name}`}
+              {...{ selectedData, activeGalaxy, autoplay }}
+              data={activeGalaxyPointData}
+              alerts={activeGalaxy ? activeGalaxy.alerts : []}
+              image={image}
+              images={activeGalaxy ? activeGalaxy.images : []}
+              selectionCallback={this.selectionCallback}
+              blinkCallback={this.onBlinkChange}
+              activeImageId={activeAlert ? activeAlert.image_id : activeImageId}
+              activeImageIndex={getActiveImageIndex(
+                activeGalaxy,
+                activeAlert,
+                activeImageIndex
+              )}
+            />
+          </div>
+        )}
+      </>
+    );
+  }
+}
+
+GalaxySupernovaSelectorContainer.propTypes = {
+  widget: PropTypes.object,
+  options: PropTypes.object,
+  answers: PropTypes.object,
+  activeQuestionId: PropTypes.string,
+  updateAnswer: PropTypes.func,
+};
+
+export default GalaxySupernovaSelectorContainer;

--- a/src/data/pages/interpreting-hubble-plot-1_2.json
+++ b/src/data/pages/interpreting-hubble-plot-1_2.json
@@ -1,16 +1,16 @@
 {
-  "id": "expand6",
+  "id": "expand6_2",
   "investigation": "expanding-universe",
-  "order": "06",
+  "order": "062",
   "title": "Constructing a Hubble plot",
-  "slug": "interpreting-a-hubble-plot-1/",
+  "slug": "interpreting-a-hubble-plot-1_2/",
   "previous": {
-    "title": "Gathering the Data for a Hubble Plot",
-    "link": "/acquiring-the-data-1/"
+    "title": "Constructing a Hubble plot",
+    "link": "/interpreting-a-hubble-plot-1/"
   },
   "next": {
     "title": "Interpreting a Hubble plot",
-    "link": "/interpreting-a-hubble-plot-1_2/"
+    "link": "/interpreting-a-hubble-plot-1_3/"
   },
   "layout": "TwoCol",
   "content": "<p>You will begin by hunting for Type Ia supernovae in Rubin Observatory images of four galaxies. Then you will identify the galaxies themselves.  Finally you will use the distances to the supernovae, and the recessional velocities of the galaxies to create a Hubble plot of your data.</p>",
@@ -20,8 +20,8 @@
       "source": "/data/galaxies/galaxy_selector.json",
       "options": {
         "autoplay": true,
-        "preSelectedId": "ZTF19abqmpsr",
-        "toggleDataPointsVisibility": "350"
+        "preSelectedId": "ZTF19abxvjkn",
+        "toggleDataPointsVisibility": "251"
       }
     }
   ],
@@ -29,7 +29,7 @@
     {
       "question": [
         {
-          "id": "350",
+          "id": "351",
           "questionType": "accordion",
           "title": "Question #1",
           "label": "<p>Identify the supernova by clicking on it. A colored circle should appear when you have correctly located it. Then identify the center of the galaxy by clicking on it. Another colored circle should appear when you have correctly located it. Repeat this process for each Galaxy in the following pages</p>",

--- a/src/data/pages/interpreting-hubble-plot-1_3.json
+++ b/src/data/pages/interpreting-hubble-plot-1_3.json
@@ -1,16 +1,16 @@
 {
-  "id": "expand6",
+  "id": "expand6_3",
   "investigation": "expanding-universe",
-  "order": "06",
+  "order": "063",
   "title": "Constructing a Hubble plot",
-  "slug": "interpreting-a-hubble-plot-1/",
+  "slug": "interpreting-a-hubble-plot-1_3/",
   "previous": {
-    "title": "Gathering the Data for a Hubble Plot",
-    "link": "/acquiring-the-data-1/"
+    "title": "Interpreting a Hubble plot",
+    "link": "/interpreting-a-hubble-plot-1_2/"
   },
   "next": {
     "title": "Interpreting a Hubble plot",
-    "link": "/interpreting-a-hubble-plot-1_2/"
+    "link": "/interpreting-a-hubble-plot-1_4/"
   },
   "layout": "TwoCol",
   "content": "<p>You will begin by hunting for Type Ia supernovae in Rubin Observatory images of four galaxies. Then you will identify the galaxies themselves.  Finally you will use the distances to the supernovae, and the recessional velocities of the galaxies to create a Hubble plot of your data.</p>",
@@ -20,8 +20,8 @@
       "source": "/data/galaxies/galaxy_selector.json",
       "options": {
         "autoplay": true,
-        "preSelectedId": "ZTF19abqmpsr",
-        "toggleDataPointsVisibility": "350"
+        "preSelectedId": "ZTF19abqqmui",
+        "toggleDataPointsVisibility": "251"
       }
     }
   ],
@@ -29,7 +29,7 @@
     {
       "question": [
         {
-          "id": "350",
+          "id": "352",
           "questionType": "accordion",
           "title": "Question #1",
           "label": "<p>Identify the supernova by clicking on it. A colored circle should appear when you have correctly located it. Then identify the center of the galaxy by clicking on it. Another colored circle should appear when you have correctly located it. Repeat this process for each Galaxy in the following pages</p>",

--- a/src/data/pages/interpreting-hubble-plot-1_4.json
+++ b/src/data/pages/interpreting-hubble-plot-1_4.json
@@ -1,16 +1,16 @@
 {
-  "id": "expand6",
+  "id": "expand6_4",
   "investigation": "expanding-universe",
-  "order": "06",
+  "order": "064",
   "title": "Constructing a Hubble plot",
-  "slug": "interpreting-a-hubble-plot-1/",
+  "slug": "interpreting-a-hubble-plot-1_4/",
   "previous": {
-    "title": "Gathering the Data for a Hubble Plot",
-    "link": "/acquiring-the-data-1/"
+    "title": "Interpreting a Hubble plot",
+    "link": "/interpreting-a-hubble-plot-1_3/"
   },
   "next": {
     "title": "Interpreting a Hubble plot",
-    "link": "/interpreting-a-hubble-plot-1_2/"
+    "link": "/interpreting-a-hubble-plot-2/"
   },
   "layout": "TwoCol",
   "content": "<p>You will begin by hunting for Type Ia supernovae in Rubin Observatory images of four galaxies. Then you will identify the galaxies themselves.  Finally you will use the distances to the supernovae, and the recessional velocities of the galaxies to create a Hubble plot of your data.</p>",
@@ -20,8 +20,8 @@
       "source": "/data/galaxies/galaxy_selector.json",
       "options": {
         "autoplay": true,
-        "preSelectedId": "ZTF19abqmpsr",
-        "toggleDataPointsVisibility": "350"
+        "preSelectedId": "ZTF19abvhduf",
+        "toggleDataPointsVisibility": "251"
       }
     }
   ],
@@ -29,7 +29,7 @@
     {
       "question": [
         {
-          "id": "350",
+          "id": "353",
           "questionType": "accordion",
           "title": "Question #1",
           "label": "<p>Identify the supernova by clicking on it. A colored circle should appear when you have correctly located it. Then identify the center of the galaxy by clicking on it. Another colored circle should appear when you have correctly located it. Repeat this process for each Galaxy in the following pages</p>",

--- a/src/data/pages/interpreting-hubble-plot-2.json
+++ b/src/data/pages/interpreting-hubble-plot-2.json
@@ -1,27 +1,27 @@
 {
-  "id": "expand6",
+  "id": "expand6_5",
   "investigation": "expanding-universe",
-  "order": "06",
+  "order": "065",
   "title": "Constructing a Hubble plot",
-  "slug": "interpreting-a-hubble-plot-1/",
+  "slug": "interpreting-a-hubble-plot-2/",
   "previous": {
-    "title": "Gathering the Data for a Hubble Plot",
-    "link": "/acquiring-the-data-1/"
+    "title": "Interpreting a Hubble plot",
+    "link": "/interpreting-a-hubble-plot-1_4/"
   },
   "next": {
     "title": "Interpreting a Hubble plot",
-    "link": "/interpreting-a-hubble-plot-1_2/"
+    "link": "/interpreting-a-hubble-plot-3/"
   },
   "layout": "TwoCol",
   "content": "<p>You will begin by hunting for Type Ia supernovae in Rubin Observatory images of four galaxies. Then you will identify the galaxies themselves.  Finally you will use the distances to the supernovae, and the recessional velocities of the galaxies to create a Hubble plot of your data.</p>",
   "widgets": [
     {
-      "type": "GalaxySupernovaSelector",
+      "type": "GalaxySelector",
       "source": "/data/galaxies/galaxy_selector.json",
       "options": {
         "autoplay": true,
-        "preSelectedId": "ZTF19abqmpsr",
-        "toggleDataPointsVisibility": "350"
+        "toggleDataPointsVisibility": "251",
+        "createUserHubblePlot": "252"
       }
     }
   ],
@@ -29,10 +29,10 @@
     {
       "question": [
         {
-          "id": "350",
+          "id": "354",
           "questionType": "accordion",
           "title": "Question #1",
-          "label": "<p>Identify the supernova by clicking on it. A colored circle should appear when you have correctly located it. Then identify the center of the galaxy by clicking on it. Another colored circle should appear when you have correctly located it. Repeat this process for each Galaxy in the following pages</p>",
+          "label": "<p>Identify the supernova by clicking on it. A colored circle should appear when you have correctly located it. Then identify the center of the galaxy by clicking on it. Another colored circle should appear when you have correctly located it. Next you will plot your selections.",
           "answerPre": "<span>Total Selected: </span>",
           "answerAccessor": "galaxy"
         }

--- a/src/data/pages/interpreting-hubble-plot-3.json
+++ b/src/data/pages/interpreting-hubble-plot-3.json
@@ -6,7 +6,7 @@
   "slug": "interpreting-a-hubble-plot-3/",
   "previous": {
     "title": "Interpreting a Hubble Plot",
-    "link": "/interpreting-a-hubble-plot-1/"
+    "link": "/interpreting-a-hubble-plot-2/"
   },
   "next": {
     "title": "Determining the Hubble Constant",

--- a/src/fragments/widgetOptions.js
+++ b/src/fragments/widgetOptions.js
@@ -26,6 +26,7 @@ export const widgetOptionsFragment = graphql`
     lightCurveTemplates
     choosePeakMagnitude
     chooseLightCurveTemplate
+    preSelectedId
     preSelectedLightCurveTemplate
     preSelectedLightCurveMagnitude
     toggleDataPointsVisibility


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4404

## What this change does ##

This change breaks out the Galaxy Selector widget over multiple pages to separate into individual galaxy interaction/selection. After the final galaxy interaction is completed the following page will be where a "new" widget will allow the user to interact with a Hubble plot utilizing the data selected from their galaxy interactions.

## Notes for reviewers ##

Please take a look at the "new" GalaxySupernovaSelector widget that was created from this work. I stripped away the GalaxySelector widget in order to create this new widget. I've also supplied the new widget with a way to pick the specific galaxy by ID to keep the same dataset throughout each page.

Requesting a review level of **8**

## Testing ##

Please test by checking if the correct galaxy is loading correctly and answers are saving between pages within the new widget.


## Checklist ##

If any of the following are true, please check them off
- [x] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does
