### PR TITLE
[EPO-4339] Right col widgets fit on screens as small as 1024 x 768

### DIFF
--- a/src/assets/stylesheets/_variables.scss
+++ b/src/assets/stylesheets/_variables.scss
@@ -19,7 +19,7 @@ $neutral10: #f3f3f3;
 $neutral20: #737373;
 $neutral30: #828287;
 $neutral40: #525459;
-$neutral45: #3A3B40;
+$neutral45: #3a3b40;
 $neutral50: #c2c2c2;
 
 $basePrimary: $ral5018HR;
@@ -62,11 +62,11 @@ $prismHexColors: $line0 $line1 $line2 $line3 $line4 $line5;
 
 // Chart colors
 $chart0: $neutral30;
-$chart1: #eD4c4c;
+$chart1: #ed4c4c;
 $chart2: #1c81a4;
-$chart3: #FaB364;
-$chart4: #3cae3F;
-$chart5: #FFe266;
+$chart3: #fab364;
+$chart4: #3cae3f;
+$chart5: #ffe266;
 $chart6: #583671;
 
 $chartColors: $chart0 $chart1 $chart2 $chart3 $chart4 $chart5 $chart6;
@@ -125,15 +125,14 @@ $break30: 320px;
 $containerMaxWidth: $break100;
 
 $siteHeaderHeight: 64px;
-$pageNavHeight: 76px;
+$pageNavHeight: 64px;
 
 $minPadding: 20px;
 
 $baseLineHeight: 1.4;
 $verticalSpace: $baseLineHeight * 1em;
-$tallestSquareWidget: calc(
-  90vh - (2 * #{$siteHeaderHeight}) - (#{$minPadding} * 4)
-);
+$headingWithSpaceHeight: 90px;
+$tallestSquareWidget: calc(100vh - #{$pageNavHeight} - #{$siteHeaderHeight} - #{$headingWithSpaceHeight} - #{$minPadding});
 
 // $durationFast: 0.1s;
 $duration: 0.2s;

--- a/src/components/charts/colorMixingTool/color-tool.module.scss
+++ b/src/components/charts/colorMixingTool/color-tool.module.scss
@@ -7,15 +7,11 @@
   }
 }
 
-.col50 {
-  width: 50%;
-}
-
 .container {
   z-index: 1;
   display: flex;
   align-items: flex-start;
-  justify-content: center;
+  justify-content: stretch;
 
   &.select-tool-container {
     z-index: 6;
@@ -27,7 +23,6 @@
   margin-top: -10px;
   font-size: 18px;
   font-weight: $regular;
-  // color: $neutral40;
 
   .sub-head-title {
     font-weight: $medium;
@@ -220,30 +215,35 @@
 
 .controls-container {
   flex-flow: column nowrap;
+  flex-grow: 1;
   align-items: stretch;
+  min-width: 400px;
+  margin-right: $minPadding;
 }
 
 .image-container {
   position: relative;
-  max-height: 800px;
-  padding-top: 50%;
-  margin: 0 $minPadding;
-  overflow: hidden;
-  // background-color: rgba(255, 255, 255, 0.02);
+  width: $tallestSquareWidget;
+  max-width: 600px;
   background-color: rgba(0, 0, 0, 0.1);
   border-radius: 3px;
   box-shadow: -4px 7px 10px -2px rgba(0, 0, 0, 0.12),
     4px 7px 10px -2px rgba(0, 0, 0, 0.12), 0 2px 3px -1px rgba(0, 0, 0, 0.24);
 
+  &::after {
+    display: block;
+    padding-bottom: 100%;
+    content: '';
+  }
+
   &.col-full-width {
-    width: 100%;
-    padding-top: 100%;
+    $colorToolHeading: 132px;
+    width: calc(100vh - #{$pageNavHeight} - #{$siteHeaderHeight} - #{$colorToolHeading} - #{$minPadding});
   }
 }
 
 .filter-image {
   position: absolute;
-  // z-index: 21;
   top: 0;
   left: 0;
   width: 100%;

--- a/src/components/visualizations/orbitalViewer/orbital-viewer.module.scss
+++ b/src/components/visualizations/orbitalViewer/orbital-viewer.module.scss
@@ -1,16 +1,13 @@
 .container {
   position: relative;
-  // width: 100%;
-  // min-width: $break30;
-  // max-width: $tallestSquareWidget;
   height: 100%;
   min-height: $break40;
-  max-height: calc(90vh - (2 * #{$siteHeaderHeight}) - (#{$minPadding} * 2));
+  max-height: $tallestSquareWidget;
   background-color: $black;
 
-  @include respond($containerMaxWidth) {
-    height: calc((100vw - #{$minPadding} * 2) / 2);
-  }
+  // @include respond($containerMaxWidth) {
+  //   height: calc((100vw - #{$minPadding} * 2) / 2);
+  // }
 }
 
 .orbital-canvas {


### PR DESCRIPTION
JIRA: [EPO-4424](https://jira.lsstcorp.org/browse/EPO-4424)

## What this change does ##

Updates the OrbitViewer and ColoringTool containers to be responsive down vertical height of 768px and horizontal width of 1024px, and any/range.combination therein.

## Notes for reviewers ##
Evaluated all widgets in Expanding Universe, Coloring the Universe, and Surveying the Solar System.  Found all were laying out acceptably but for the OrbitViewer and the ColoringTool (and its no controls variant)

Include an indication of how detailed a review you want on a 1-10 scale: 5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"

## Testing ##
Squish that browser window all over the darned place.

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reused styles, widgets, pages, QAs, utility methods, etc.)
- [X] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does