### PR TITLE
[EPO-4402] Disable TOC links if earliest questions not answered

### DIFF
--- a/src/components/charts/colorMixingTool/index.jsx
+++ b/src/components/charts/colorMixingTool/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import isArray from 'lodash/isArray';
+import filter from 'lodash/filter';
 import SliderCustom from '../../site/slider/index.jsx';
 import Select from '../../site/selectField/index.jsx';
 import Button from '../../site/button/index.js';
@@ -170,7 +171,13 @@ class ColorTool extends React.PureComponent {
       () => {
         const { selectedData, selectorValue } = this.state;
         if (selectionCallback) {
-          selectionCallback(selectedData, selectorValue);
+          const activeFilters = filter(selectedData.filters, {
+            active: true,
+          });
+
+          if (activeFilters > 0) {
+            selectionCallback(selectedData, selectorValue);
+          }
         }
       }
     );

--- a/src/components/site/tableOfContents/index.jsx
+++ b/src/components/site/tableOfContents/index.jsx
@@ -7,7 +7,11 @@ import classnames from 'classnames';
 import { Drawer } from 'react-md';
 import Check from '../icons/Check';
 import Progress from '../progress/index.jsx';
-import { tableOfContents, heading } from './table-of-contents.module.scss';
+import {
+  tableOfContents,
+  heading,
+  disabledLink,
+} from './table-of-contents.module.scss';
 
 @reactn
 class TableOfContents extends React.PureComponent {
@@ -25,6 +29,7 @@ class TableOfContents extends React.PureComponent {
           } = link;
           const baseUrl = linkBaseUrl && useBaseUrl ? `/${linkBaseUrl}/` : '/';
           const isActive = this.isActivePage(id);
+          const allQsComplete = this.checkQAProgress(id);
 
           return {
             component: Link,
@@ -33,9 +38,11 @@ class TableOfContents extends React.PureComponent {
             primaryText: `${pageNumber}. ${title}`,
             leftIcon: <Check />,
             active: isActive,
+            disabled: !allQsComplete && !isActive,
             className: classnames('toc-link', `link--page-id--${id}`, {
               'link-active': isActive,
-              'qa-progress--complete': this.checkQAProgress(id),
+              'qa-progress--complete': allQsComplete,
+              [disabledLink]: !allQsComplete && !isActive,
             }),
           };
         }

--- a/src/components/site/tableOfContents/table-of-contents.module.scss
+++ b/src/components/site/tableOfContents/table-of-contents.module.scss
@@ -79,6 +79,10 @@
     margin: 0;
   }
 
+  .disabled-link {
+    pointer-events: none;
+  }
+
   :global {
     .md-list {
       height: calc(100vh - 324px);


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4402

## What this change does ##

Disable TOC links when the earlier questions have not been answered to keep from "jumping around" in the investigation.
## Notes for reviewers ##

Create a new css class that disables `pointer-events`. This works in tandem with the `disabled` param on the `links` object created in the TOC. I'm also mutated (slightly) the `checkQAProgress` function in the `tableOfContents/index.jsx` that now takes a specific `state` (e.g. 1 or 0) to determine the state of the page in question. I then use this to determine in disabled state of each link per its page. Works nicely with the progress states.

Include an indication of how detailed a review you want on a 1-10 scale. **5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"**

## Testing ##

Testing can be done by trying to navigate through the app without answering the questions and with answering the questions.


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does
