### PR TITLE
[EPO-4400] HubblePlot is zoomable

### DIFF
--- a/src/components/charts/asteroidClass/index.jsx
+++ b/src/components/charts/asteroidClass/index.jsx
@@ -239,46 +239,48 @@ class AsteroidClass extends React.Component {
               offsetTop={offsetTop}
               scale={yScale}
             />
-            {maxs && mins && (
-              <Region
-                type={styles.filtersRegion}
-                points={this.getRegionPoints()}
-                xValueAccessor="x"
-                yValueAccessor="y"
-                {...{ xScale, yScale, offsetTop, offsetRight }}
-              />
-            )}
-            {data && (
-              <Points
-                {...{
-                  data,
-                  xScale,
-                  yScale,
-                  selectedData,
-                  hoveredData,
-                  offsetTop,
-                }}
-                pointClasses={classnames(styles.point)}
-              />
-            )}
-            {mins && maxs && means && (
-              <Summary
-                filters={this.filters}
-                means={means}
-                mins={mins}
-                maxs={maxs}
-                {...{ xScale, yScale, offsetTop }}
-              />
-            )}
-            {overlayData && (
-              <FilterValuesLine
-                lineClasses={styles.overlayLine}
-                pointClasses={styles.overlayPoint}
-                filters={this.filters}
-                filterValues={overlayData}
-                {...{ xScale, yScale, offsetTop }}
-              />
-            )}
+            <g clipPath="url('#clip')">
+              {maxs && mins && (
+                <Region
+                  type={styles.filtersRegion}
+                  points={this.getRegionPoints()}
+                  xValueAccessor="x"
+                  yValueAccessor="y"
+                  {...{ xScale, yScale, offsetTop, offsetRight }}
+                />
+              )}
+              {data && (
+                <Points
+                  {...{
+                    data,
+                    xScale,
+                    yScale,
+                    selectedData,
+                    hoveredData,
+                    offsetTop,
+                  }}
+                  pointClasses={classnames(styles.point)}
+                />
+              )}
+              {mins && maxs && means && (
+                <Summary
+                  filters={this.filters}
+                  means={means}
+                  mins={mins}
+                  maxs={maxs}
+                  {...{ xScale, yScale, offsetTop }}
+                />
+              )}
+              {overlayData && (
+                <FilterValuesLine
+                  lineClasses={styles.overlayLine}
+                  pointClasses={styles.overlayPoint}
+                  filters={this.filters}
+                  filterValues={overlayData}
+                  {...{ xScale, yScale, offsetTop }}
+                />
+              )}
+            </g>
           </svg>
         </div>
       </>

--- a/src/components/charts/galacticProperties/index.jsx
+++ b/src/components/charts/galacticProperties/index.jsx
@@ -367,7 +367,7 @@ class GalacticProperties extends React.Component {
               offsetTop={offsetTop}
               scale={yScale}
             />
-            <g>
+            <g clipPath="url('#clip')">
               {data &&
                 multiple &&
                 data.map((set, i) => {

--- a/src/components/charts/sizeDistance/index.jsx
+++ b/src/components/charts/sizeDistance/index.jsx
@@ -361,7 +361,7 @@ class SizeDistance extends React.Component {
               offsetTop={offsetTop}
               scale={yScale}
             />
-            <g>
+            <g clipPath="url('#clip')">
               {data &&
                 multiple &&
                 data.map((set, i) => {


### PR DESCRIPTION
JIRA: [EPO-4400](https://jira.lsstcorp.org/browse/EPO-4400)

## What this change does ##

HubblePlot is zoomable if it is a HubblePlot where the user is placing points.  Non-interactive HubblePlots and Trendline placement HubblePlots are not zoomable.

## Notes for reviewers ##

Uses same D3 zoom strategy as implemented in other D3 SVGs like the light curve templates.

Include an indication of how detailed a review you want on a 1-10 scale: 5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"

## Testing ##
[Best example of this kind of HubblePlot currently](https://604a8a09a7e41a00075439a7--investigations.netlify.app/expanding-universe/interpreting-a-hubble-plot-2/) (I guess will change as @georgegomez144 finishes creating a standalone "HubblePlotter" component).

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reused styles, widgets, pages, QAs, utility methods, etc.)
- [X] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots ##

