### PR TITLE
[EPO-4399] Add tables to QA Review page

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "serve": "gatsby serve",
     "test": "jest --verbose",
     "watch-test": "jest --watch --verbose",
-    "clean": "gatsby clean"
+    "clean": "gatsby clean",
+    "develop": "yarn clean && yarn start"
   },
   "repository": {
     "type": "git",

--- a/src/components/qas/styles.module.scss
+++ b/src/components/qas/styles.module.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable declaration-no-important */
 .qa {
   + .qa {
     margin-top: $minPadding / 4;
@@ -28,14 +29,14 @@
   .qa-review-label-post,
   .calculator-label,
   p {
-    font-size: 16px !important; /* stylelint-disable-line declaration-no-important *//* stylelint-disable-line declaration-no-important *//* stylelint-disable-line declaration-no-important */
-    font-weight: $medium !important; /* stylelint-disable-line declaration-no-important *//* stylelint-disable-line declaration-no-important */
-    color: $basePrimary !important; /* stylelint-disable-line declaration-no-important */
+    font-size: 16px !important;
+    font-weight: $medium !important;
+    color: $basePrimary !important;
   }
 }
 
 .qa-review-block {
-  margin: 0 !important; /* stylelint-disable-line declaration-no-important */
+  margin: 0 !important;
   font-size: 16px;
   font-weight: $medium;
   color: $basePrimary;
@@ -59,7 +60,7 @@
   .qa-review-inline-input {
     display: inline-block;
     max-width: 180px;
-    margin-top: 0 !important; /* stylelint-disable-line declaration-no-important */
+    margin-top: 0 !important;
     text-decoration: underline;
   }
 
@@ -74,4 +75,9 @@
       text-decoration: underline;
     }
   }
+}
+
+.qa-review-table-container {
+  max-width: 800px;
+  margin: 2 * $minPadding $minPadding;
 }

--- a/src/fragments/pageMeta.js
+++ b/src/fragments/pageMeta.js
@@ -7,6 +7,7 @@ export const pageMetaFragment = graphql`
     layout
     slug
     title
+    order
     content
     next {
       title


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4399

## What this change does ##

This commit updates the GraphQL query to use the PageContainer's query in order to set up and pull in all elements of the investigation. This also includes the `ObservationsTable` component in order to render the "now available" tables in the QA Review page.

## Notes for reviewers ##

Changes can be found on the `qa-review` page. Look for the tables loaded at the bottom of the QA Review page.

Include an indication of how detailed a review you want on a 1-10 scale. **5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"**

## Testing ##

Testing this change can be seen by "filling in" the tables through the investigation and checking to see the answer is correctly populated in the QA Review page.


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
![image](https://user-images.githubusercontent.com/8799443/111204113-08d02200-8583-11eb-979b-9f34d4415e27.png)

### After:
![image](https://user-images.githubusercontent.com/8799443/111203748-9c552300-8582-11eb-9be1-fba0e90689a3.png)

