### PR TITLE
[EPO-4397] Add widgets to the QA Review page

### DIFF
--- a/src/components/charts/prismWidget/prism-widget.module.scss
+++ b/src/components/charts/prismWidget/prism-widget.module.scss
@@ -1,4 +1,5 @@
 .content-wrapper {
+  position: relative;
   margin: auto;
   overflow: hidden;
   text-align: center;
@@ -233,6 +234,10 @@
 
 .background {
   position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   z-index: -2;
   width: 100%;
   height: 350px;
@@ -241,9 +246,9 @@
 
 .select-container {
   display: block;
-  width: 25%;
-  margin-right: auto;
-  margin-left: auto;
+  padding: 0 40% 20px;
+  margin: 0 auto;
+  background-color: $black;
 
   .select-label {
     min-width: 150px;

--- a/src/components/qas/styles.module.scss
+++ b/src/components/qas/styles.module.scss
@@ -77,7 +77,15 @@
   }
 }
 
+.qa-review-page-container {
+  display: block;
+}
+
 .qa-review-table-container {
   max-width: 800px;
   margin: 2 * $minPadding $minPadding;
+}
+
+.qa-review-widget-container {
+  margin: $minPadding;
 }

--- a/src/containers/QAReviewContainer.jsx
+++ b/src/containers/QAReviewContainer.jsx
@@ -7,9 +7,14 @@ import find from 'lodash/find';
 import filter from 'lodash/filter';
 import flattenDeep from 'lodash/flattenDeep';
 import ObservationsTable from '../components/charts/shared/observationsTables/ObservationsTable';
+import Widget from '../components/widgets/index';
 import QAs from '../components/qas';
 import Button from '../components/site/button/index.js';
-import { qaReviewTableContainer } from '../components/qas/styles.module.scss';
+import {
+  qaReviewPageContainer,
+  qaReviewTableContainer,
+  qaReviewWidgetContainer,
+} from '../components/qas/styles.module.scss';
 
 @reactn
 class QAReviewContainer extends React.PureComponent {
@@ -52,6 +57,17 @@ class QAReviewContainer extends React.PureComponent {
             return table;
           });
         }
+        if (inv.widgets) {
+          inv.widgets = inv.widgets.map(widget => {
+            widget.options = {
+              ...widget.options,
+              qaReview: true,
+              disabled: true,
+              autoplay: false,
+            };
+            return widget;
+          });
+        }
         return inv;
       });
 
@@ -63,6 +79,10 @@ class QAReviewContainer extends React.PureComponent {
       filteredByInvestigation.filter(inv => !!inv.tables)
     );
 
+    const widgets = flattenDeep(
+      filteredByInvestigation.filter(inv => !!inv.widgets)
+    );
+
     this.setState(prevState => ({
       ...prevState,
       data,
@@ -71,6 +91,7 @@ class QAReviewContainer extends React.PureComponent {
       questions,
       answers,
       tables,
+      widgets,
     }));
 
     this.dispatch.updatePageId(null);
@@ -92,7 +113,7 @@ class QAReviewContainer extends React.PureComponent {
           <>
             {pages &&
               pages.map(page => {
-                const { questionsByPage: questions, tables } = page;
+                const { questionsByPage: questions, tables, widgets } = page;
                 const shared = {
                   questions,
                   answers,
@@ -103,7 +124,10 @@ class QAReviewContainer extends React.PureComponent {
                   activeQuestionId: '',
                 };
                 return (
-                  <span key={`page-${page.id}`}>
+                  <span
+                    key={`page-${page.id}`}
+                    className={qaReviewPageContainer}
+                  >
                     {questions && <QAs {...shared} />}
                     {tables &&
                       tables.map((table, tableIndex) => (
@@ -115,6 +139,18 @@ class QAReviewContainer extends React.PureComponent {
                           <ObservationsTable {...table} answers={answers} />
                         </div>
                       ))}
+                    {widgets &&
+                      widgets.map(widget => {
+                        const { options, type } = widget || {};
+                        return (
+                          <div
+                            key={`widget-${widget.type}`}
+                            className={qaReviewWidgetContainer}
+                          >
+                            <Widget {...{ widget, options, type, ...shared }} />
+                          </div>
+                        );
+                      })}
                   </span>
                 );
               })}


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4397

## What this change does ##

This change adds the widgets to the QA Review page. Used the same method of the tables to load these widgets. Created a container class to make sure the widget fits in the bounds of the page.

## Notes for reviewers ##

Well, the QA Review page is the place to be when reviewing this PR.

There is a style change to the PrismTool that was breaking on the QA Review page, and well, this change makes the layout in the investigation a little cleaner.

Include an indication of how detailed a review you want on a 1-10 scale.
**5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"**

## Testing ##

n/a


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
![2021-03-16_15-56-41 (1)](https://user-images.githubusercontent.com/8799443/111390630-478fd600-8670-11eb-89e3-aa7258a375bd.gif)

### After:
![2021-03-16_15-48-56 (1)](https://user-images.githubusercontent.com/8799443/111390422-f08a0100-866f-11eb-8861-4421362a3660.gif)

