### PR TITLE
[EPO-4350] Order and add number to pages in QA Review

### DIFF
--- a/src/components/qas/styles.module.scss
+++ b/src/components/qas/styles.module.scss
@@ -43,6 +43,7 @@
 
   .answer-label,
   .answer-label p {
+    display: inline-block;
     @extend .qa-review-block;
   }
 

--- a/src/data/pages/asteroid-impact-3.json
+++ b/src/data/pages/asteroid-impact-3.json
@@ -1,7 +1,7 @@
 {
   "id": "hazardous21a",
   "investigation": "hazardous-asteroids",
-  "order": "21a",
+  "order": "21.1",
   "title": "Evaluating the Consequences of an Asteroid Impact",
   "slug": "asteroid-impact-3/",
   "previous": {
@@ -20,11 +20,7 @@
         "col": "right",
         "row": "top"
       },
-      "rowTitles": [
-        ["Mass"],
-        ["Velocity"],
-        ["Kinetic Energy"]
-      ],
+      "rowTitles": [["Mass"], ["Velocity"], ["Kinetic Energy"]],
       "colTitles": ["", "Asteroid #1", "Asteroid #2", "Asteroid #3"],
       "rows": [
         [

--- a/src/data/pages/determining-orbits-1.json
+++ b/src/data/pages/determining-orbits-1.json
@@ -1,7 +1,7 @@
 {
   "id": "hazardous08a",
   "investigation": "hazardous-asteroids",
-  "order": "08a",
+  "order": "08.1",
   "title": "Determining the Orbit of an Asteroid",
   "slug": "determining-orbits-1/",
   "previous": {
@@ -21,10 +21,28 @@
       "options": {
         "defaultZoom": 0.5,
         "potentialOrbits": true,
-        "observations":[
-          {"id": "obs-1", "label": "#1","interactable": false, "isActive": false, "position": 0.55},
-          {"id": "obs-2", "label": "#2","interactable": false, "isActive": false, "position": 0.6},
-          {"id": "obs-3", "label": "#3","interactable": false, "isActive": false, "position": 0.65}
+        "observations": [
+          {
+            "id": "obs-1",
+            "label": "#1",
+            "interactable": false,
+            "isActive": false,
+            "position": 0.55
+          },
+          {
+            "id": "obs-2",
+            "label": "#2",
+            "interactable": false,
+            "isActive": false,
+            "position": 0.6
+          },
+          {
+            "id": "obs-3",
+            "label": "#3",
+            "interactable": false,
+            "isActive": false,
+            "position": 0.65
+          }
         ]
       }
     }

--- a/src/data/pages/determining-orbits-1a.json
+++ b/src/data/pages/determining-orbits-1a.json
@@ -1,7 +1,7 @@
 {
   "id": "hazardous08b",
   "investigation": "hazardous-asteroids",
-  "order": "08b",
+  "order": "08.2",
   "title": "Determining the Orbit of an Asteroid",
   "slug": "determining-orbits-1a/",
   "previous": {
@@ -21,9 +21,21 @@
       "options": {
         "defaultZoom": 0.5,
         "potentialOrbits": true,
-        "observations":[
-          {"id": "obs-1", "label": "#1","interactable": false, "isActive": false, "position": 0.55},
-          {"id": "obs-2", "label": "#2","interactable": false, "isActive": false, "position": 0.6}
+        "observations": [
+          {
+            "id": "obs-1",
+            "label": "#1",
+            "interactable": false,
+            "isActive": false,
+            "position": 0.55
+          },
+          {
+            "id": "obs-2",
+            "label": "#2",
+            "interactable": false,
+            "isActive": false,
+            "position": 0.6
+          }
         ]
       }
     }

--- a/src/data/pages/determining-orbits-5-1.json
+++ b/src/data/pages/determining-orbits-5-1.json
@@ -1,7 +1,7 @@
 {
   "id": "hazardous12a",
   "investigation": "hazardous-asteroids",
-  "order": "12a",
+  "order": "12.1",
   "title": "Determining the Orbit of an Asteroid",
   "slug": "determining-orbits-5-1/",
   "previous": {
@@ -21,15 +21,63 @@
         "defaultZoom": 0.5,
         "potentialOrbits": true,
         "questionId": "21",
-        "observations":[
-          {"id": "obs-1", "label": "#1","interactable": false, "isActive": false, "position": 0.55},
-          {"id": "obs-2", "label": "#2","interactable": false, "isActive": false, "position": 0.6},
-          {"id": "obs-3", "label": "#3","interactable": false, "isActive": false, "position": 0.65},
-          {"id": "obs-4", "label": "#4","interactable": false, "isActive": false, "position": 0.7},
-          {"id": "obs-5", "label": "A","interactable": true, "isActive": true, "position": 0.75},
-          {"id": "obs-7", "label": "B","interactable": true, "isActive": false, "position": 0.9},
-          {"id": "obs-8", "label": "C","interactable": true, "isActive": false, "position": 0.08},
-          {"id": "obs-9", "label": "D","interactable": true, "isActive": false, "position": 0.25}
+        "observations": [
+          {
+            "id": "obs-1",
+            "label": "#1",
+            "interactable": false,
+            "isActive": false,
+            "position": 0.55
+          },
+          {
+            "id": "obs-2",
+            "label": "#2",
+            "interactable": false,
+            "isActive": false,
+            "position": 0.6
+          },
+          {
+            "id": "obs-3",
+            "label": "#3",
+            "interactable": false,
+            "isActive": false,
+            "position": 0.65
+          },
+          {
+            "id": "obs-4",
+            "label": "#4",
+            "interactable": false,
+            "isActive": false,
+            "position": 0.7
+          },
+          {
+            "id": "obs-5",
+            "label": "A",
+            "interactable": true,
+            "isActive": true,
+            "position": 0.75
+          },
+          {
+            "id": "obs-7",
+            "label": "B",
+            "interactable": true,
+            "isActive": false,
+            "position": 0.9
+          },
+          {
+            "id": "obs-8",
+            "label": "C",
+            "interactable": true,
+            "isActive": false,
+            "position": 0.08
+          },
+          {
+            "id": "obs-9",
+            "label": "D",
+            "interactable": true,
+            "isActive": false,
+            "position": 0.25
+          }
         ]
       }
     }

--- a/src/data/pages/haz-summary-4.json
+++ b/src/data/pages/haz-summary-4.json
@@ -1,7 +1,7 @@
 {
   "id": "hazardous26a",
   "investigation": "hazardous-asteroids",
-  "order": "26a",
+  "order": "26.1",
   "title": "Effects of an Asteroid Impact",
   "slug": "summary-4/",
   "previous": {

--- a/src/data/pages/haz-summary-5.json
+++ b/src/data/pages/haz-summary-5.json
@@ -1,7 +1,7 @@
 {
   "id": "hazardous26c",
   "investigation": "hazardous-asteroids",
-  "order": "26c",
+  "order": "26.3",
   "title": "Effects of an Asteroid Impact",
   "slug": "summary-5/",
   "previous": {

--- a/src/data/pages/interpreting-hubble-plot-1_2.json
+++ b/src/data/pages/interpreting-hubble-plot-1_2.json
@@ -1,7 +1,7 @@
 {
   "id": "expand6_2",
   "investigation": "expanding-universe",
-  "order": "062",
+  "order": "06.2",
   "title": "Constructing a Hubble plot",
   "slug": "interpreting-a-hubble-plot-1_2/",
   "previous": {

--- a/src/data/pages/interpreting-hubble-plot-1_3.json
+++ b/src/data/pages/interpreting-hubble-plot-1_3.json
@@ -1,7 +1,7 @@
 {
   "id": "expand6_3",
   "investigation": "expanding-universe",
-  "order": "063",
+  "order": "06.3",
   "title": "Constructing a Hubble plot",
   "slug": "interpreting-a-hubble-plot-1_3/",
   "previous": {

--- a/src/data/pages/interpreting-hubble-plot-1_4.json
+++ b/src/data/pages/interpreting-hubble-plot-1_4.json
@@ -1,7 +1,7 @@
 {
   "id": "expand6_4",
   "investigation": "expanding-universe",
-  "order": "064",
+  "order": "06.4",
   "title": "Constructing a Hubble plot",
   "slug": "interpreting-a-hubble-plot-1_4/",
   "previous": {

--- a/src/data/pages/interpreting-hubble-plot-2.json
+++ b/src/data/pages/interpreting-hubble-plot-2.json
@@ -1,7 +1,7 @@
 {
   "id": "expand6_5",
   "investigation": "expanding-universe",
-  "order": "065",
+  "order": "06.5",
   "title": "Constructing a Hubble plot",
   "slug": "interpreting-a-hubble-plot-2/",
   "previous": {

--- a/src/data/pages/nebula-theory.json
+++ b/src/data/pages/nebula-theory.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem19a",
   "investigation": "solar-system",
-  "order": "19a",
+  "order": "19.1",
   "title": "The History of the Solar System",
   "slug": "nebula-theory/",
   "previous": {


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4350

## What this change does ##

This change ensures that questions/pages load in order as shown in the investigation on the QA Review page. This change also adds the question numbers. I used a similar method found in the `PageContainer.jsx` file.

## Notes for reviewers ##

There were a few `.json` pages that were updated (the `order` field) to make sure that the pages/questions are loaded correctly in order.

Include an indication of how detailed a review you want on a 1-10 scale: **5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"**

## Testing ##

n/a


## Checklist ##

If any of the following are true, please check them off
- [x] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [ ] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
![2021-03-17_09-09-24 (1)](https://user-images.githubusercontent.com/8799443/111499886-a4d36800-8700-11eb-9b1f-b4ee6ca2908d.gif)

### After:
![2021-03-17_09-16-19 (1)](https://user-images.githubusercontent.com/8799443/111500878-b2d5b880-8701-11eb-834d-cef87a09afa1.gif)
