### PR TITLE
[EPO-4398] Disable all widgets on the QA Review Page

### DIFF
--- a/src/components/charts/colorMixingTool/index.jsx
+++ b/src/components/charts/colorMixingTool/index.jsx
@@ -169,13 +169,13 @@ class ColorTool extends React.PureComponent {
         ...newState,
       }),
       () => {
-        const { selectedData, selectorValue } = this.state;
+        const { data, selectedData, selectorValue } = this.state;
         if (selectionCallback) {
           const activeFilters = filter(selectedData.filters, {
             active: true,
           });
 
-          if (activeFilters > 0) {
+          if (isArray(data) || activeFilters > 0) {
             selectionCallback(selectedData, selectorValue);
           }
         }
@@ -195,6 +195,7 @@ class ColorTool extends React.PureComponent {
       hideControls,
       hideImage,
       hideSubHeadTitle,
+      qaReview,
     } = this.props;
     const { data, selectedData, resetBtnActive, selectorValue } = this.state;
     const filters = selectedData ? selectedData.filters : [];
@@ -254,6 +255,7 @@ class ColorTool extends React.PureComponent {
                     value={selectorValue}
                     saveListScrollTop
                     fullWidth
+                    disabled={qaReview}
                     listStyle={{ width: '100%' }}
                     // position="below"
                   />
@@ -396,6 +398,7 @@ ColorTool.propTypes = {
   hideControls: PropTypes.bool,
   hideImage: PropTypes.bool,
   hideSubHeadTitle: PropTypes.bool,
+  qaReview: PropTypes.bool,
 };
 
 export default ColorTool;

--- a/src/components/charts/prismWidget/index.jsx
+++ b/src/components/charts/prismWidget/index.jsx
@@ -79,6 +79,7 @@ class PrismWidget extends React.PureComponent {
   };
 
   render() {
+    const { qaReview } = this.props;
     const { selectedColor } = this.state;
     const colors = [
       'Red',
@@ -179,6 +180,7 @@ class PrismWidget extends React.PureComponent {
             block
             position="top left"
             fullWidth
+            disabled={qaReview}
             simplifiedMenu={false}
             listStyle={{
               left: 0,
@@ -196,6 +198,7 @@ class PrismWidget extends React.PureComponent {
 PrismWidget.propTypes = {
   selectionCallback: PropTypes.func,
   selectedColor: PropTypes.string,
+  qaReview: PropTypes.bool,
 };
 
 export default PrismWidget;

--- a/src/containers/AstroToolContainer.jsx
+++ b/src/containers/AstroToolContainer.jsx
@@ -159,6 +159,7 @@ class AstroToolContainer extends React.PureComponent {
       hideControls,
       hideImage,
       hideSubHeadTitle,
+      qaReview,
     } = options || {};
     const { jsonData, selectorValue, selectedData } = this.state;
     const { title, colorOptions, hexColors, data: dataObjects } =
@@ -187,6 +188,7 @@ class AstroToolContainer extends React.PureComponent {
             hideControls,
             hideImage,
             hideSubHeadTitle,
+            qaReview,
           }}
           menuItems={this.getMenuItems()}
           colorBlocks={this.getColorBlocks()}

--- a/src/containers/GalaxiesFilterSelectorContainer.jsx
+++ b/src/containers/GalaxiesFilterSelectorContainer.jsx
@@ -144,6 +144,11 @@ class GalaxiesFilterSelectorContainer extends React.PureComponent {
       selectedData,
     } = this.state;
 
+    const { widget } = this.props;
+    const {
+      options: { preSelected },
+    } = widget || {};
+
     return (
       <>
         <h2 className="space-bottom heading-primary">
@@ -172,7 +177,7 @@ class GalaxiesFilterSelectorContainer extends React.PureComponent {
             <div className="galaxy-selector-images--container">
               <GalaxySelector
                 className={`galaxy-selector-${data.name}`}
-                {...{ selectedData, activeGalaxy }}
+                {...{ selectedData, activeGalaxy, preSelected }}
                 data={activeGalaxyPointData}
                 image={activeGalaxy.image}
                 selectionCallback={this.selectionCallback}

--- a/src/containers/GalaxySupernovaSelectorContainer.jsx
+++ b/src/containers/GalaxySupernovaSelectorContainer.jsx
@@ -123,7 +123,7 @@ class GalaxySupernovaSelectorContainer extends React.PureComponent {
     } = this.state;
 
     const { options } = this.props;
-    const { image, autoplay } = options || {};
+    const { image, autoplay, preSelected } = options || {};
 
     return (
       <>
@@ -134,7 +134,7 @@ class GalaxySupernovaSelectorContainer extends React.PureComponent {
           <div className="galaxy-selector-images--container">
             <GalaxySelector
               className={`galaxy-selector-${data.name}`}
-              {...{ selectedData, activeGalaxy, autoplay }}
+              {...{ selectedData, activeGalaxy, autoplay, preSelected }}
               data={activeGalaxyPointData}
               alerts={activeGalaxy ? activeGalaxy.alerts : []}
               image={image}

--- a/src/containers/PrismWidgetContainer.jsx
+++ b/src/containers/PrismWidgetContainer.jsx
@@ -25,15 +25,15 @@ class PrismWidgetContainer extends React.PureComponent {
 
   render() {
     const { widget } = this.props;
-    const {
-      options: { questionId },
-    } = widget || {};
+    const { options } = widget || {};
+    const { questionId, qaReview } = options || {};
 
     return (
       <PrismWidget
         selectedColor={this.getSelectedColor()}
         hasQuestionId={questionId !== null}
         selectionCallback={this.selectionCallback}
+        {...{ qaReview }}
       />
     );
   }

--- a/src/containers/QAReviewContainer.jsx
+++ b/src/containers/QAReviewContainer.jsx
@@ -75,7 +75,7 @@ class QAReviewContainer extends React.PureComponent {
       widget.options = {
         ...widget.options,
         qaReview: true,
-        disabled: true,
+        preSelected: true,
         autoplay: false,
       };
 


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4398

## What this change does ##

Add some additional customizations to certain widgets inorder to "disable" their functionality on the QA Review page. I utilized the `qaReview: false` param and passed that into the widgets on the QA Review page and from there utilized that as a way to `disable` any interactable widget features still functional on the QA Review page. I also utilized the predefined options (`preSelected: true`, `autoplay: false`) to render the widgets inactive.

## Notes for reviewers ##

n/a

Include an indication of how detailed a review you want on a 1-10 scale.: **5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"**

## Testing ##

n/a


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
![2021-03-17_13-40-33 (1)](https://user-images.githubusercontent.com/8799443/111535524-6cdf1b80-8726-11eb-8ecd-eaecd5da21aa.gif)

### After:
![2021-03-17_13-37-41 (1)](https://user-images.githubusercontent.com/8799443/111535162-0f4acf00-8726-11eb-8b98-291c24fc65c1.gif)

