### PR TITLE
[EPO-4468]  HubblePlotter points are draggable

### DIFF
--- a/src/assets/stylesheets/components/charts/_tooltip.scss
+++ b/src/assets/stylesheets/components/charts/_tooltip.scss
@@ -3,7 +3,7 @@
   padding: 8px;
   font: 12px sans-serif;
   pointer-events: none;
-  background: lightsteelblue;
+  background: $lightBlue;
   border: 0;
   border-radius: 8px;
 }

--- a/src/components/charts/hubblePlot/Points.jsx
+++ b/src/components/charts/hubblePlot/Points.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import includes from 'lodash/includes';
+import find from 'lodash/find';
 import classnames from 'classnames';
 import Point from './Point.jsx';
 import { notActive, invisible } from './hubble-plot.module.scss';
@@ -25,6 +25,7 @@ class Points extends React.PureComponent {
       pointClasses,
       offsetTop,
       colorize,
+      draggedPoint,
     } = this.props;
 
     return (
@@ -34,8 +35,9 @@ class Points extends React.PureComponent {
           const key = `point-${id}-${i}`;
           const x = d[xValueAccessor];
           const y = d[yValueAccessor];
-          const selected = includes(selectedData, d);
-          const hovered = includes(hoveredData, d);
+          const selected = !!find(selectedData, d);
+          const hovered = !!find(hoveredData, d);
+
           const classes = classnames('data-point', pointClasses, {
             [`data-point-${this.classify(name || ' ')}`]: !!name,
             [`color-${i + 1}-translucent-fill`]: colorize,
@@ -43,7 +45,7 @@ class Points extends React.PureComponent {
             selected,
             hovered,
             [notActive]: (selectedData || hoveredData) && !selected && !hovered,
-            [invisible]: x === null || y === null,
+            [invisible]: x === null || y === null || draggedPoint === d,
           });
 
           return (
@@ -74,6 +76,7 @@ Points.propTypes = {
   pointClasses: PropTypes.string,
   offsetTop: PropTypes.number,
   colorize: PropTypes.bool,
+  draggedPoint: PropTypes.object,
 };
 
 export default Points;


### PR DESCRIPTION
JIRA: [EPO-4468](https://jira.lsstcorp.org/browse/4468)

## What this change does ##
- If active galaxy has no point placed user should see "ghost point" and be able to place point on 
- If active galaxy has a point already user should be able to adjust its placement by dragging and dropping
- If user clicks or drags a non-active galaxy point that point and its corresponding galaxy should become active
- This new interactivity should be scoped to the HubblePlotter only (not the normal HubblePlot or the HubblePlotWIthTrendline or the combo with the 3D stufff)

## Notes for reviewers ##
To work around the drag event colliding with the normal click event I had to get creative in terms of what a drag-start and drag-end events trigger, especially in the absence of any drag fired in between.  Feels...a bit frail, but held up in testing.

This is a 7.

## Testing ##
I tested in the 4 contexts I could think of: Hubble/Plotter, hubblePlot, HubblePlotWIthTrendline, and the combo of it and the 3D positional graph.  But I tested most exhaustively in the former.  Please check across all these contexts and any I may be missing in the expanding universe investigation.  Please test all available interactivity and UI (point placement, side menu, full sidebar menu, and next/previous buttons, etc) in the widget when there are no points and/or no answer (fresh start), when some but not all points have been placed, when all points have been placed, after clearing points through QA UI.  Please test across browsers.
There does seem to be some edge cases where the ghost point disappears during drag.  Please provide indication of reproducibility and and thoughts on fix.


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [ X ] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
https://user-images.githubusercontent.com/8166060/111666671-2abee400-87d1-11eb-9bda-9ff17a36c209.mov

### After:
https://user-images.githubusercontent.com/8166060/111671625-5ee8d380-87d6-11eb-9387-92ac1169da01.mov

