### PR TITLE
[EPO-4473] Update histogram tooltip to allow "out of" totals

### DIFF
--- a/src/assets/stylesheets/components/charts/_tooltip.scss
+++ b/src/assets/stylesheets/components/charts/_tooltip.scss
@@ -3,7 +3,7 @@
   padding: 8px;
   font: 12px sans-serif;
   pointer-events: none;
-  background: $lightBlue;
-  border: 0;
+  background: $baseSecondaryLight;
+  border: 1px solid $neutral40;
   border-radius: 8px;
 }

--- a/src/components/charts/histogram/index.jsx
+++ b/src/components/charts/histogram/index.jsx
@@ -418,6 +418,16 @@ class Histogram extends React.PureComponent {
     });
   }
 
+  calculateTotalNumberOfObjects(dataset) {
+    let count = 0;
+    if (dataset) {
+      dataset.forEach(d => {
+        count += d.length;
+      });
+    }
+    return count;
+  }
+
   render() {
     const {
       // data: meanData,
@@ -448,6 +458,8 @@ class Histogram extends React.PureComponent {
       groupNames,
       activePlots,
     } = this.state;
+
+    const totalObjects = this.calculateTotalNumberOfObjects(data);
 
     const svgClasses = classnames('histogram svg-chart', {
       loading,
@@ -483,6 +495,7 @@ class Histogram extends React.PureComponent {
             key="tooltip"
             graph="histogram"
             data={selectedData || hoveredData}
+            dataTotal={totalObjects}
             posX={tooltipPosX}
             posY={tooltipPosY}
             show={showTooltip}

--- a/src/components/charts/orbitalProperties/index.jsx
+++ b/src/components/charts/orbitalProperties/index.jsx
@@ -46,7 +46,11 @@ class OrbitalProperties extends React.PureComponent {
           />
         ) : (
           <div className={loadingWrapper}>
-            <CircularProgress className="chart-loader" scale={3} />
+            <CircularProgress
+              id="chart-loader"
+              className="chart-loader"
+              scale={3}
+            />
           </div>
         )}
       </>

--- a/src/components/charts/shared/Tooltip.jsx
+++ b/src/components/charts/shared/Tooltip.jsx
@@ -108,12 +108,20 @@ class Tooltip extends React.PureComponent {
   }
 
   renderAccessor(accessor, label, data, unit) {
+    const { dataTotal } = this.props;
     const isCount = accessor === 'count';
+    const isCountOfTotal = accessor === 'countOfTotal';
 
     let content = '';
 
     if (isCount) {
       content = this.renderValue(accessor, data.length, unit || label);
+    } else if (isCountOfTotal) {
+      content = this.renderValue(
+        accessor,
+        [data.length, dataTotal],
+        unit || label
+      );
     } else if (data.length > 1) {
       content = this.renderRange(accessor, data, unit);
     } else if (data.length === 1) {
@@ -122,7 +130,9 @@ class Tooltip extends React.PureComponent {
 
     return (
       <div className="value-row" key={accessor}>
-        {!isCount && <span>{label || capitalize(accessor)}: </span>}
+        {!isCount && !isCountOfTotal && (
+          <span>{label || capitalize(accessor)}: </span>
+        )}
         {content}
       </div>
     );
@@ -161,6 +171,7 @@ Tooltip.defaultProps = {
 Tooltip.propTypes = {
   graph: PropTypes.string,
   data: PropTypes.array,
+  dataTotal: PropTypes.number,
   posX: PropTypes.number,
   posY: PropTypes.number,
   show: PropTypes.bool,

--- a/src/data/pages/characterizing-comet.json
+++ b/src/data/pages/characterizing-comet.json
@@ -72,7 +72,7 @@
             "yAxisLabel": "Number of comets",
             "domain": [[0, 100], []],
             "bins": 20,
-            "tooltipAccessors": ["count", "semimajor_axis"],
+            "tooltipAccessors": ["countOfTotal", "semimajor_axis"],
             "tooltipLabels": ["Comets", "Orbit Size (au)"]
           }
         },
@@ -86,7 +86,7 @@
             "yAxisLabel": "Number of comets",
             "domain": [[0, 1], []],
             "bins": 10,
-            "tooltipAccessors": ["count", "eccentricity"],
+            "tooltipAccessors": ["countOfTotal", "eccentricity"],
             "tooltipLabels": ["Comets", "Eccentricity"]
           }
         },
@@ -100,7 +100,7 @@
             "yAxisLabel": "Number of comets",
             "domain": [[0, 180], []],
             "bins": 9,
-            "tooltipAccessors": ["count", "inclination"],
+            "tooltipAccessors": ["countOfTotal", "inclination"],
             "tooltipLabels": ["Comets", "Inclination (degrees)"]
           }
         }

--- a/src/data/pages/characterizing-mba.json
+++ b/src/data/pages/characterizing-mba.json
@@ -72,7 +72,7 @@
             "xValueAccessor": "semimajor_axis",
             "domain": [[0, 10], []],
             "bins": 20,
-            "tooltipAccessors": ["count", "semimajor_axis"],
+            "tooltipAccessors": ["countOfTotal", "semimajor_axis"],
             "tooltipLabels": ["MBAs", "Orbit Size (au)"]
           }
         },
@@ -86,7 +86,7 @@
             "xValueAccessor": "eccentricity",
             "domain": [[0, 1], []],
             "bins": 10,
-            "tooltipAccessors": ["count", "eccentricity"],
+            "tooltipAccessors": ["countOfTotal", "eccentricity"],
             "tooltipLabels": ["MBAs", "Eccentricity"]
           }
         },
@@ -100,7 +100,7 @@
             "xValueAccessor": "inclination",
             "domain": [[0, 180], []],
             "bins": 9,
-            "tooltipAccessors": ["count", "inclination"],
+            "tooltipAccessors": ["countOfTotal", "inclination"],
             "tooltipLabels": ["MBAs", "Inclination (degrees)"]
           }
         }

--- a/src/data/pages/characterizing-neo.json
+++ b/src/data/pages/characterizing-neo.json
@@ -72,7 +72,7 @@
             "yAxisLabel": "Number of NEOs",
             "domain": [[0, 10], []],
             "bins": 20,
-            "tooltipAccessors": ["count", "semimajor_axis"],
+            "tooltipAccessors": ["countOfTotal", "semimajor_axis"],
             "tooltipLabels": ["NEOs", "Orbit Size (au)"]
           }
         },
@@ -86,7 +86,7 @@
             "yAxisLabel": "Number of NEOs",
             "domain": [[0, 1], []],
             "bins": 10,
-            "tooltipAccessors": ["count", "eccentricity"],
+            "tooltipAccessors": ["countOfTotal", "eccentricity"],
             "tooltipLabels": ["NEOs", "Eccentricity"]
           }
         },
@@ -100,7 +100,7 @@
             "yAxisLabel": "Number of NEOs",
             "domain": [[0, 180], null],
             "bins": 9,
-            "tooltipAccessors": ["count", "inclination"],
+            "tooltipAccessors": ["countOfTotal", "inclination"],
             "tooltipLabels": ["NEOs", "Inclination (degrees)"]
           }
         }

--- a/src/lib/utilities.js
+++ b/src/lib/utilities.js
@@ -1,6 +1,7 @@
 import isEmpty from 'lodash/isEmpty';
 import includes from 'lodash/includes';
 import isNumber from 'lodash/isNumber';
+import isArray from 'lodash/isArray';
 import { extent as d3Extent, mean as d3Mean } from 'd3-array';
 import chartColors from '../assets/stylesheets/_variables.scss';
 
@@ -242,6 +243,15 @@ const getDamageDescription = function(data) {
   return data.description;
 };
 
+const getCountOutOfTotal = function(data) {
+  if (!isArray(data)) return null;
+  const [count, total] = data;
+  const formattedCount = addTheCommas(formatValue(count));
+  const formattedTotal = addTheCommas(formatValue(total));
+
+  return `${formattedCount} of ${formattedTotal}`;
+};
+
 export const getValue = function(accessor, data) {
   return (
     {
@@ -270,7 +280,8 @@ export const getValue = function(accessor, data) {
       diameter: formatValue(data, 0),
       craterDiameter: addTheCommas(toSigFigs(data, 3)),
       craterDepth: addTheCommas(toSigFigs(data, 3)),
-      count: formatValue(data ? data.length : 0, 0),
+      count: addTheCommas(formatValue(data ? data.length : 0, 0)),
+      countOfTotal: getCountOutOfTotal(data),
       kineticEnergy: addTheCommas(toSigFigs(+data, 3)),
       volume: toSigFigs(data, 4),
       overPressure: addTheCommas(toSigFigs(data, 3)),


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4473

## What this change does ##

This change updates the tooltips in the histograms to now show "<number> out of <total_number>" when using the `countOfTotal` in `tooltipAccessors`. This is change required me to add another custom accessor type in the Tooltip component.

## Notes for reviewers ##

This change can be found in the Histogram component as well as in the Tooltip component. Small note, I added an `id` to the CircularProgress component on the OrbitalProperties component because it was firing and error within console.

Include an indication of how detailed a review you want on a 1-10 scale.: **5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"**

## Testing ##

By hovering the mouse of the bins in the histograms to show the tooltip.


## Checklist ##

If any of the following are true, please check them off
- [x] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
![image](https://user-images.githubusercontent.com/8799443/113365667-cab95900-930b-11eb-902d-dda73bfb5bfc.png)

### After:
![image](https://user-images.githubusercontent.com/8799443/113365641-b70df280-930b-11eb-878f-9736eb110da6.png)
