### PR TITLE
[EPO-4552] Replace prism html with svg

### DIFF
--- a/src/assets/stylesheets/_variables.scss
+++ b/src/assets/stylesheets/_variables.scss
@@ -44,19 +44,25 @@ $md-switch-ball-fallback-color: $md-switch-fallback-color;
 $md-slider-warn-md: false; // only need to set this if using the dark theme.
 
 // Prism Colors
-$line0: #ec1c24;
-$line1: #f18922;
-$line2: #ffdd15;
-$line3: #6bd853;
-$line4: #0019ff;
-$line5: #861cff;
+$prismIndigo: #861cff;
+$prismBlue: #0019ff;
+$prismGreen: #6bd853;
+$prismYellow: #ffdd15;
+$prismOrange: #f18922;
+$prismRed: #ec1c24;
 
-$prismHexColors: $line0 $line1 $line2 $line3 $line4 $line5;
+$prismHexColors: (
+  'indigo': $prismIndigo,
+  'blue': $prismBlue,
+  'green': $prismGreen,
+  'yellow': $prismYellow,
+  'orange': $prismOrange,
+  'red': $prismRed,
+);
 
 :export {
-  @for $i from 0 through length($prismHexColors) - 1 {
-    $prismColor: nth($prismHexColors, $i + 1);
-    line#{$i}: $prismColor;
+  @each $color, $hex in $prismHexColors {
+    #{$color}: $hex;
   }
 }
 

--- a/src/components/charts/prismWidget/index.jsx
+++ b/src/components/charts/prismWidget/index.jsx
@@ -4,35 +4,7 @@ import classnames from 'classnames';
 import Select from '../../site/selectField/index.jsx';
 import ArrowDown from '../../site/icons/ArrowDown';
 
-import {
-  prismShape,
-  whiteStreak,
-  streak,
-  prismClipWrapper,
-  prismItems,
-  prismColors,
-  lens,
-  cameraFilter,
-  whiteCover,
-  single,
-  prismWrapper,
-  contentWrapper,
-  filterLabel,
-  prismLabel,
-  whiteLightLabel,
-  hideLabel,
-  prismSmallClipWrapper,
-  prismSmallWrapper,
-  prismSmallItems,
-  prismSmallColors,
-  whiteSmallCover,
-  background,
-  selectContainer,
-  selectLabel,
-  visibleRay,
-  hiddenRay,
-  stripe,
-} from './prism-widget.module.scss';
+import styles from './prism-widget.module.scss';
 import prismHexColors from '../../../assets/stylesheets/_variables.scss';
 
 class PrismWidget extends React.PureComponent {
@@ -41,6 +13,16 @@ class PrismWidget extends React.PureComponent {
 
     this.state = {
       selectedColor: 'None',
+    };
+
+    this.prismColors = {
+      Red: prismHexColors.red,
+      Orange: prismHexColors.orange,
+      Yellow: prismHexColors.yellow,
+      Green: prismHexColors.green,
+      Blue: prismHexColors.blue,
+      Indigo: prismHexColors.indigo,
+      None: 'transparent',
     };
   }
 
@@ -56,11 +38,6 @@ class PrismWidget extends React.PureComponent {
   handleSelect = value => {
     this.updateAnswers(value);
   };
-
-  getPrismColors(index) {
-    if (index === 6) return { backgroundColor: 'transparent' };
-    return { backgroundColor: prismHexColors[`line${index}`] };
-  }
 
   updateAnswers = value => {
     this.setState(
@@ -78,119 +55,229 @@ class PrismWidget extends React.PureComponent {
     );
   };
 
+  hideArrow(color) {
+    const { selectedColor } = this.props;
+    return selectedColor !== color && selectedColor !== 'None';
+  }
+
   render() {
     const { qaReview } = this.props;
     const { selectedColor } = this.state;
-    const colors = [
-      'Red',
-      'Orange',
-      'Yellow',
-      'Green',
-      'Blue',
-      'Indigo',
-      'None',
-    ];
 
     return (
-      <div>
+      <>
         <h2>Filter Tool</h2>
-        <div className={contentWrapper}>
-          <div className={background}></div>
-          <div className={prismShape}>
-            <div className={`${streak} ${whiteStreak}`}></div>
-            <div className={prismSmallClipWrapper}>
-              <div className={prismSmallWrapper}>
-                <div className={prismSmallItems}>
-                  {colors.map((color, i) => {
-                    return (
-                      <div
-                        key={`div-${color}-lens`}
-                        className={prismSmallColors}
-                        name={color}
-                        style={this.getPrismColors(i)}
-                      ></div>
-                    );
-                  })}
-                </div>
-              </div>
-            </div>
-            <div className={`${whiteSmallCover}`}></div>
-            <div className={prismClipWrapper}>
-              <div className={prismWrapper}>
-                <div className={prismItems}>
-                  {colors.map((color, i) => {
-                    let rays = ``;
-                    if (color === selectedColor) {
-                      rays += `${visibleRay}`;
-                    } else if (color !== 'None') {
-                      rays += `${hiddenRay}`;
-                    }
-
-                    return (
-                      <div
-                        key={`div-${color}-lens`}
-                        className={`${prismColors} ${rays}`}
-                        name={color}
-                        style={this.getPrismColors(i)}
-                      ></div>
-                    );
-                  })}
-                  {colors.map((color, i) => {
-                    return (
-                      <div
-                        key={`div-${color}-lens`}
-                        className={`${lens} ${
-                          color === selectedColor ? stripe : cameraFilter
-                        }`}
-                        style={
-                          color === selectedColor ? this.getPrismColors(i) : {}
-                        }
-                        id={color}
-                      ></div>
-                    );
-                  })}
-                  <div
-                    className={`${lens} ${whiteCover}`}
-                    style={selectedColor !== 'None' ? { display: 'block' } : {}}
-                  ></div>
-                  <div className={`${prismColors} ${single}`}></div>
-                </div>
-              </div>
-            </div>
-            <p
-              className={classnames(filterLabel, {
-                [hideLabel]: selectedColor === 'None',
-              })}
+        <div className={styles.contentWrapper}>
+          <svg
+            version="1.1"
+            id="Layer_1"
+            x="0px"
+            y="0px"
+            viewBox="0 0 1551.6 736.7"
+          >
+            <defs>
+              <linearGradient id="no-arrow-red">
+                <stop offset="0%" stopColor={this.prismColors.Red} />
+                <stop offset="81%" stopColor={this.prismColors.Red} />
+                <stop offset="81%" stopColor="transparent" />
+                <stop offset="100%" stopColor="transparent" />
+              </linearGradient>
+              <linearGradient id="no-arrow-orange">
+                <stop offset="0%" stopColor={this.prismColors.Orange} />
+                <stop offset="80%" stopColor={this.prismColors.Orange} />
+                <stop offset="80%" stopColor="transparent" />
+                <stop offset="100%" stopColor="transparent" />
+              </linearGradient>
+              <linearGradient id="no-arrow-yellow">
+                <stop offset="0%" stopColor={this.prismColors.Yellow} />
+                <stop offset="79%" stopColor={this.prismColors.Yellow} />
+                <stop offset="79%" stopColor="transparent" />
+                <stop offset="100%" stopColor="transparent" />
+              </linearGradient>
+              <linearGradient id="no-arrow-green">
+                <stop offset="0%" stopColor={this.prismColors.Green} />
+                <stop offset="78%" stopColor={this.prismColors.Green} />
+                <stop offset="78%" stopColor="transparent" />
+                <stop offset="100%" stopColor="transparent" />
+              </linearGradient>
+              <linearGradient id="no-arrow-blue">
+                <stop offset="0%" stopColor={this.prismColors.Blue} />
+                <stop offset="77%" stopColor={this.prismColors.Blue} />
+                <stop offset="77%" stopColor="transparent" />
+                <stop offset="100%" stopColor="transparent" />
+              </linearGradient>
+              <linearGradient id="no-arrow-indigo">
+                <stop offset="0%" stopColor={this.prismColors.Indigo} />
+                <stop offset="77%" stopColor={this.prismColors.Indigo} />
+                <stop offset="77%" stopColor="transparent" />
+                <stop offset="100%" stopColor="transparent" />
+              </linearGradient>
+            </defs>
+            <radialGradient
+              id="gradient_1_"
+              cx="718.4264"
+              cy="-294.6529"
+              r="417.8"
+              fx="638.9412"
+              fy="-303.5418"
+              gradientTransform="matrix(1 0 0 1 0 534)"
+              gradientUnits="userSpaceOnUse"
             >
+              <stop offset="0.12" style={{ stopColor: '#FFFFFF' }} />
+              <stop offset="1" style={{ stopColor: '#000000' }} />
+            </radialGradient>
+            <polygon
+              id="gradient"
+              points="653.2,127 867.4,498 438.9,498"
+              fill="url(#gradient_1_)"
+              style={{ opacity: 0.3 }}
+            />
+            <text transform="matrix(1 0 0 1 1206.5464 164.1372)" fill="#ffffff">
               Filter
-            </p>
-            <p className={prismLabel}>Prism</p>
-            <p className={whiteLightLabel}>White Light → </p>
+            </text>
+            <line
+              id="white_ray"
+              className={styles.whiteLine}
+              x1="108.2"
+              y1="463.3"
+              x2="546.1"
+              y2="312.5"
+            />
+            <line
+              id="white_light_arrow_line"
+              className={styles.whiteLine}
+              x1="376.8"
+              y1="327.9"
+              x2="430"
+              y2="309.6"
+            />
+            <polygon
+              id="white_light_arrow"
+              points="420.7,325.4 428.1,310.3 413,302.9 422.5,299.7 437.6,307 430.2,322.1"
+              fill="#ffffff"
+            />
+            <text
+              transform="matrix(0.9446 -0.3282 0.3282 0.9446 152.0965 417.697)"
+              fill="#ffffff"
+            >
+              White light
+            </text>
+            <text transform="matrix(1 0 0 1 598.2964 606.0872)" fill="#ffffff">
+              Prism
+            </text>
+            <g id="rays_out">
+              <path
+                id="indigo_ray"
+                className={classnames(styles.rayIndigo, {
+                  [styles.noArrow]: this.hideArrow('Indigo'),
+                })}
+                d="M546.1,312.5l212.8,1.9h0.4l0.5,0.2L1396,522.8c6.9,2.3,10.7,9.7,8.5,16.7s-9.7,10.7-16.7,8.5l0,0l-0.4-0.1L757.8,320.4l0.9,0.2L546.1,312.5z"
+              />
+              <polygon
+                id="indigo_arrow"
+                className={styles.arrowIndigo}
+                points="1426.5,547.9 1353.2,550.6 1377.9,530.1 1372.3,498.5"
+              />
+              <path
+                id="blue_ray"
+                className={classnames(styles.rayBlue, {
+                  [styles.noArrow]: this.hideArrow('Blue'),
+                })}
+                d="M546.1,312.4l206.5-4.4h0.4l0.4,0.1l641.1,164c7,1.8,11.2,8.9,9.4,15.9c-1.8,7-8.9,11.2-15.9,9.4l-0.4-0.1L751.8,313.8l0.8,0.1L546.1,312.4z"
+              />
+              <polygon
+                id="blue_arrow"
+                className={styles.arrowBlue}
+                points="1431.5,496.4 1358.6,504.1 1381.8,482 1374.1,450.9"
+              />
+              <path
+                id="green_ray"
+                className={classnames(styles.rayGreen, {
+                  [styles.noArrow]: this.hideArrow('Green'),
+                })}
+                d="M547.8,312l200.6-10.6h0.3l0.4,0.1l644.8,120.3c7,1.4,11.5,8.2,10.1,15.2c-1.4,6.9-8,11.4-14.9,10.2l-0.4-0.1L747.8,307.4l0.7,0.1L547.8,312z"
+              />
+              <polygon
+                id="green_arrow"
+                className={styles.arrowGreen}
+                points="1437.9,443.4 1366.1,458.4 1387,434.1 1376.2,403.9"
+              />
+              <path
+                id="yellow_ray"
+                className={classnames(styles.rayYellow, {
+                  [styles.noArrow]: this.hideArrow('Yellow'),
+                })}
+                d="M546.1,312.5l205.8-17.3h0.3h0.4l640.4,75.3c7.1,0.8,12.2,7.2,11.3,14.3c-0.8,7.1-7.2,12.2-14.3,11.3l-0.4-0.1l-637.9-94.5h0.6L546.1,312.5z"
+              />
+              <polygon
+                id="yellow_arrow"
+                className={styles.arrowYellow}
+                points="1438.9,389.7 1368,408.2 1387.6,382.8 1375.4,353.3"
+              />
+              <path
+                id="orange_ray"
+                className={classnames(styles.rayOrange, {
+                  [styles.noArrow]: this.hideArrow('Orange'),
+                })}
+                d="M546.1,311l189.3-21.8h0.2h0.3l656.5,33.3c7,0.4,12.4,6.3,12,13.3s-6.3,12.4-13.3,12h-0.4l-655.2-52.9h0.5L546.1,311z"
+              />
+              <polygon
+                id="orange_arrow"
+                className={styles.arrowOrange}
+                points="1443.7,340.3 1373.9,362.8 1392.1,336.4 1378.2,307.5"
+              />
+              <path
+                id="red_ray"
+                className={classnames(styles.rayRed, {
+                  [styles.noArrow]: this.hideArrow('Red'),
+                })}
+                d="M546.1,311L730,283.9h0.1h0.2l661.4-9.9c6.9-0.1,12.6,5.4,12.7,12.3s-5.4,12.6-12.3,12.7h-0.4l-661.4-9.8h0.4L546.1,311z"
+              />
+              <polygon
+                id="red_arrow"
+                className={styles.arrowRed}
+                points="1441.9,290 1372.4,313.2 1390.3,286.6 1376.1,257.9"
+              />
+            </g>
+            <line
+              id="filter"
+              className={styles.filter}
+              x1="1255.6"
+              y1="235.7"
+              x2="1193.1"
+              y2="550.3"
+              stroke={this.prismColors[selectedColor]}
+              fill="#ffffff"
+            />
+            <polygon
+              id="outline"
+              className={styles.prismOutline}
+              points="653.2,127 760.3,312.5 867.4,498 653.2,498 438.9,498 546.1,312.5 "
+            />
+          </svg>
+          <div className={styles.selectContainer}>
+            <p className={styles.selectLabel}>Select a filter:</p>
+            <Select
+              dropdownIcon={<ArrowDown />}
+              id="color-select"
+              className="set-white-color"
+              menuItems={Object.keys(this.prismColors)}
+              onChange={this.handleSelect}
+              value={selectedColor}
+              block
+              position="top left"
+              fullWidth
+              disabled={qaReview}
+              simplifiedMenu={false}
+              listStyle={{
+                left: 0,
+                top: '100%',
+                width: '100%',
+              }}
+            />
           </div>
         </div>
-        <div className={selectContainer}>
-          <p className={selectLabel}>Select a filter:</p>
-          <Select
-            dropdownIcon={<ArrowDown />}
-            id="color-select"
-            className="set-white-color"
-            menuItems={colors}
-            onChange={this.handleSelect}
-            value={selectedColor}
-            block
-            position="top left"
-            fullWidth
-            disabled={qaReview}
-            simplifiedMenu={false}
-            listStyle={{
-              left: 0,
-              top: '100%',
-              width: '100%',
-              minWidth: '150px',
-            }}
-          />
-        </div>
-      </div>
+      </>
     );
   }
 }

--- a/src/components/charts/prismWidget/prism-widget.module.scss
+++ b/src/components/charts/prismWidget/prism-widget.module.scss
@@ -1,258 +1,61 @@
 .content-wrapper {
-  position: relative;
-  margin: auto;
-  overflow: hidden;
-  text-align: center;
+  font-size: 42px;
+  background-color: #000000;
 }
 
-.visibleRay {
-  z-index: 3;
+.prism-outline {
+  fill: none;
+  stroke: #ffffff;
+  stroke-miterlimit: 10;
+  stroke-width: 12;
 }
 
-.hiddenRay {
-  z-index: 0;
+.white-line {
+  fill: none;
+  stroke: #ffffff;
+  stroke-miterlimit: 10;
+  stroke-width: 7;
 }
 
-.stripe {
-  top: -58px;
-  top: '-36px';
-  right: 84px;
-  z-index: 1;
-  z-index: 1;
-  width: 7px;
-  visibility: 'visible';
-  opacity: 1;
-  transition: 'all 1.2s ease 0s';
+.filter {
+  fill: none;
+  stroke-linecap: round;
+  stroke-miterlimit: 10;
+  stroke-width: 27.27;
 }
 
-.prism-shape {
-  position: relative;
-  left: -100px;
-  width: 150px;
-  height: 150px;
-  margin: 32px auto 80px;
-  border-bottom: 3px solid $protonWhite;
+@mixin prismClasses {
+  $noArrow: '#no-arrow';
 
-  &::before,
-  &::after {
-    position: absolute;
-    bottom: 0;
-    z-index: 3;
-    width: 150px;
-    height: 3px;
-    content: '';
-    background: $protonWhite;
-  }
+  @each $color, $hex in $prismHexColors {
+    .ray-#{$color} {
+      fill: $hex;
 
-  &::before {
-    right: -72px;
-    transform: rotate(60deg) translateX(-47%);
-  }
+      &.no-arrow {
+        fill: url(#{$noArrow}-#{$color});
+      }
+    }
 
-  &::after {
-    left: -72px;
-    transform: rotate(-60deg) translateX(47%);
-  }
+    .arrow-#{$color} {
+      fill: $hex;
+    }
 
-  .white-streak {
-    position: absolute;
-    width: 300px;
-    height: 2px;
-    background: $protonWhite;
-    border-radius: 10px 0 0 10px;
-    transform: rotate(-13deg) translateY(calc(100% + 110px));
+    .ray-#{$color}.no-arrow + .arrow-#{$color} {
+      opacity: 0;
+    }
   }
 }
 
-.streak {
-  top: 15px;
-  left: -286px;
-}
-
-.prism-small-clip-wrapper {
-  position: absolute;
-  top: 9px;
-  left: 12px;
-  z-index: -1;
-  display: flex;
-  width: 221px;
-  height: 96px;
-  overflow: hidden;
-  transform: rotate(9deg);
-}
-
-.prism-small-wrapper {
-  position: relative;
-  width: 161px;
-  height: 30px;
-  margin: 68px auto auto -27px;
-  transform: rotate(-24deg);
-  perspective: 9px;
-}
-
-.prism-small-items {
-  position: absolute;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  transform: rotateY(-14.5deg);
-
-  .prism-small-colors {
-    flex-grow: 1;
-  }
-}
-
-.prism-shape {
-  .prism-wrapper {
-    position: relative;
-    width: 400px;
-    height: 100px;
-    margin: 80px auto auto -120px;
-    transform: rotate(36deg);
-    perspective: 150px;
-  }
-
-  .prism-clip-wrapper {
-    position: absolute;
-    top: -201px;
-    left: 155px;
-    z-index: 1;
-    display: flex;
-    width: 700px;
-    height: 520px;
-    overflow: hidden;
-    transform: rotate(-31deg);
-  }
-
-  .white-light-label,
-  .prism-label,
-  .filter-label {
-    position: absolute;
-    color: $protonWhite;
-  }
-
-  .white-light-label {
-    top: 60px;
-    left: -100px;
-    float: left;
-    transform: rotate(-13deg);
-  }
-
-  .prism-label {
-    top: 156px;
-    left: 53px;
-  }
-
-  .filter-label {
-    top: 0;
-    left: 280px;
-    z-index: 20;
-  }
-
-  .hide-label {
-    display: none;
-  }
-}
-
-.prism-radio {
-  margin-top: 30px;
-  margin-left: 30px;
-}
-
-@-webkit-keyframes glow {
-  to {
-    flex-grow: 1;
-    width: 100%;
-  }
-}
-
-@keyframes glow {
-  to {
-    flex-grow: 1;
-    width: 100%;
-  }
-}
-
-.prism-items {
-  position: absolute;
-  display: flex;
-  flex-direction: column;
-  width: 120%;
-  height: 100%;
-  margin-top: -4px;
-  transform: rotateY(-20deg);
-
-  .prism-colors {
-    flex-grow: 1;
-  }
-}
-
-.lens {
-  position: absolute;
-  top: -37px;
-  right: 164px;
-  width: 10px;
-  height: 170px;
-  background-color: $protonWhite;
-  border-radius: 10px;
-}
-
-.camera-filter {
-  top: -58px;
-  right: 84px;
-  z-index: 1;
-  width: 7px;
-  visibility: hidden;
-  opacity: 0;
-  transition: visibility 0s, opacity 0.1s linear;
-
-  &:active {
-    top: -27px;
-  }
-}
-
-.white-cover {
-  top: -45px;
-  right: -36px;
-  display: none;
-  width: 200px;
-  height: 200px;
-  background-color: $black;
-}
-
-.white-small-cover {
-  position: absolute;
-  top: 2px;
-  left: 87px;
-  display: block;
-  width: 154px;
-  height: 39px;
-  background-color: $black;
-  transform: rotate(-2deg);
-}
-
-.background {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: -2;
-  width: 100%;
-  height: 350px;
-  background-color: $black;
-}
+@include prismClasses;
 
 .select-container {
   display: block;
-  padding: 0 40% 20px;
+  width: 150px;
+  padding-bottom: $minPadding;
   margin: 0 auto;
-  background-color: $black;
+  background-color: #000000;
 
   .select-label {
-    min-width: 150px;
-    margin-bottom: 0;
     color: $white;
   }
 
@@ -265,7 +68,7 @@
 
       .md-select-field {
         .md-select-field--text-field {
-          min-width: 150px;
+          width: 150px;
           padding: 20px 15px;
           background-color: white;
           border-radius: 5px;
@@ -279,74 +82,6 @@
           display: none;
         }
       }
-    }
-  }
-}
-
-@media only screen and (max-width: $break100) {
-  .prism-shape {
-    left: -15px;
-  }
-
-  .white-small-cover {
-    transform: rotate(-1deg);
-  }
-
-  .white-cover {
-    right: 40px;
-  }
-
-  .lens:not(.white-cover) {
-    right: 230px;
-  }
-
-  .prism-items {
-    width: 120%;
-  }
-
-  .prism-shape {
-    .filter-label {
-      left: 200px;
-    }
-  }
-}
-
-@media only screen and (max-width: $break50) {
-  .prism-items {
-    width: 110%;
-    margin-top: -2px;
-  }
-
-  .prism-shape {
-    left: 20px;
-  }
-
-  .white-cover {
-    right: 70px;
-  }
-
-  .lens:not(.white-cover) {
-    right: 260px;
-  }
-
-  .white-small-cover {
-    z-index: 0;
-    width: 100%;
-    transform: rotate(-1deg);
-  }
-
-  .content-wrapper {
-    .prism-shape {
-      .white-light-label {
-        top: 50px;
-        left: -70px;
-      }
-    }
-  }
-
-  .prism-shape {
-    .filter-label {
-      left: 140px;
     }
   }
 }


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4552

## What this change does ##

This change "migrates" the prism tool structure from HTML to SVG for cleaner animations and scaling between browsers. The update also removes all unused styles and code.

## Notes for reviewers ##

Changes can be found in both the `/prismWidget/index.js` as well as its `prism-widget.module.scss`.

Include an indication of how detailed a review you want on a 1-10 scale: - 5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"

## Testing ##

n/a


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
![image](https://user-images.githubusercontent.com/8799443/114596786-e6dec380-9c44-11eb-86f9-b95e2c015fd3.png)

### After:
![PrismTool_SVG](https://user-images.githubusercontent.com/8799443/114596717-cca4e580-9c44-11eb-95f6-cd779ffbbab3.gif)

