### PR TITLE
[EPO-4651] Update Color Filter Tool to use the canvas element

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,11 +1,11 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import axe from 'react-axe';
+// import React from 'react';
+// import ReactDOM from 'react-dom';
+// import axe from 'react-axe';
 
 import './src/assets/stylesheets/styles.scss';
 
-export const onInitialClientRender = () => {
-  if (process.env.NODE_ENV === 'development') {
-    axe(React, ReactDOM, 1000);
-  }
-};
+// export const onInitialClientRender = () => {
+//   if (process.env.NODE_ENV === 'development') {
+//     axe(React, ReactDOM, 1000);
+//   }
+// };

--- a/src/components/charts/colorMixingTool/FilterImage.jsx
+++ b/src/components/charts/colorMixingTool/FilterImage.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class FilterImage extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.canvasRef = React.createRef();
+    this.background = new Image();
+  }
+
+  componentDidMount() {
+    const { image, color, height, width } = this.props;
+    this.updateCanvas(image, color, width, height);
+  }
+
+  componentDidUpdate(prevProps) {
+    const { image, color, height, width } = this.props;
+    const { color: prevColor, image: prevImage } = prevProps;
+
+    if (color !== prevColor || image !== prevImage) {
+      this.updateCanvas(image, color, width, height);
+    }
+  }
+
+  updateColor(ctx, color, width, height) {
+    ctx.beginPath();
+    ctx.rect(0, 0, width, height);
+    ctx.closePath();
+    ctx.fillStyle = color || 'transparent';
+    ctx.fill();
+  }
+
+  updateCanvas(image, color, width, height) {
+    const imgPath = image ? `/images/colorTool/${image}` : '';
+    const ctx = this.canvasRef.current.getContext('2d');
+
+    ctx.clearRect(0, 0, width, height);
+    ctx.globalCompositeOperation = 'multiply';
+
+    this.background.onload = () => {
+      ctx.drawImage(this.background, 0, 0, width, height);
+      this.updateColor(ctx, color, height, width);
+    };
+
+    this.background.src = imgPath;
+  }
+
+  render() {
+    const { className, width, height, brightness } = this.props;
+
+    return (
+      <canvas
+        className={className}
+        ref={this.canvasRef}
+        width={width}
+        height={height}
+        style={{ filter: `brightness(${brightness}) contrast(1.3)` }}
+      />
+    );
+  }
+}
+
+FilterImage.defaultProps = {
+  height: 600,
+  width: 600,
+};
+
+FilterImage.propTypes = {
+  className: PropTypes.string,
+  height: PropTypes.number,
+  width: PropTypes.number,
+  image: PropTypes.string,
+  color: PropTypes.string,
+  brightness: PropTypes.number,
+};
+
+export default FilterImage;

--- a/src/components/charts/colorMixingTool/color-tool.module.scss
+++ b/src/components/charts/colorMixingTool/color-tool.module.scss
@@ -238,7 +238,9 @@
 
   &.col-full-width {
     $colorToolHeading: 132px;
-    width: calc(100vh - #{$pageNavHeight} - #{$siteHeaderHeight} - #{$colorToolHeading} - #{$minPadding});
+    width: calc(
+      100vh - #{$pageNavHeight} - #{$siteHeaderHeight} - #{$colorToolHeading} - #{$minPadding}
+    );
   }
 }
 
@@ -246,13 +248,7 @@
   position: absolute;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
   visibility: hidden;
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: cover;
-  background-blend-mode: multiply;
   mix-blend-mode: screen;
   opacity: 0;
 }

--- a/src/components/charts/colorMixingTool/color-tool.module.scss
+++ b/src/components/charts/colorMixingTool/color-tool.module.scss
@@ -230,6 +230,11 @@
   box-shadow: -4px 7px 10px -2px rgba(0, 0, 0, 0.12),
     4px 7px 10px -2px rgba(0, 0, 0, 0.12), 0 2px 3px -1px rgba(0, 0, 0, 0.24);
 
+  @media print {
+    height: 600px;
+    background-color: transparent;
+  }
+
   &::after {
     display: block;
     padding-bottom: 100%;

--- a/src/components/charts/colorMixingTool/index.jsx
+++ b/src/components/charts/colorMixingTool/index.jsx
@@ -7,6 +7,7 @@ import SliderCustom from '../../site/slider/index.jsx';
 import Select from '../../site/selectField/index.jsx';
 import Button from '../../site/button/index.js';
 import ArrowDown from '../../site/icons/ArrowDown';
+import FilterImage from './FilterImage';
 import {
   getResetBtnState,
   getDataAndPrepare,
@@ -354,17 +355,15 @@ class ColorTool extends React.PureComponent {
                   });
 
                   return (
-                    <div
+                    <FilterImage
                       key={`filter-${label}`}
                       className={imageClassName}
-                      style={{
-                        backgroundImage: image
-                          ? `url(/images/colorTool/${image}`
-                          : 'none',
-                        backgroundColor: color,
-                        filter: `brightness(${brightness}) contrast(1.3)`,
+                      {...{
+                        image,
+                        color,
+                        brightness,
                       }}
-                    ></div>
+                    />
                   );
                 })}
             </div>

--- a/src/components/qas/styles.module.scss
+++ b/src/components/qas/styles.module.scss
@@ -117,9 +117,10 @@
 }
 
 .qa-review-widget-container {
-  width: 800px;
+  width: 100%;
+  max-width: 1200px;
 
   @media print {
-    width: 50%;
+    width: 70%;
   }
 }

--- a/src/components/site/slider/index.jsx
+++ b/src/components/site/slider/index.jsx
@@ -22,6 +22,7 @@ class SliderCustom extends React.PureComponent {
     } = this.props;
     return (
       <Slider
+        step={step || 1}
         {...{
           id,
           className,
@@ -33,7 +34,6 @@ class SliderCustom extends React.PureComponent {
           discrete,
           min,
           max,
-          step,
           value,
           defaultValue,
         }}


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4651

## What this change does ##

No longer will it use the 'background-image' property (since that does not render in printer view). Now comes the time for the "CANVAS" element, which does render as asked.

## Notes for reviewers ##

Still a bit buggy since, the filtered images won't load "right-off-the-bat" when previously answered.

Include an indication of how detailed a review you want on a 1-10 scale. - 5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"

## Testing ##

n/a


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
