### PR TITLE
[EPO-4648] Add "All Questions Answered" notification

### DIFF
--- a/src/components/site/answersCompletedAlert/answers-completed.module.scss
+++ b/src/components/site/answersCompletedAlert/answers-completed.module.scss
@@ -1,0 +1,71 @@
+.answers-completed {
+  position: fixed;
+  bottom: -200px;
+  left: 50%;
+  z-index: 10;
+  display: inline-block;
+  max-width: 460px;
+  padding: $minPadding;
+  background-color: #55da59;
+  border-radius: $minPadding;
+  transition: bottom $durationSuperSlow $timing;
+  transform: translateX(-50%);
+
+  &.show-answers-completed {
+    bottom: $pageNavHeight + $minPadding;
+    transition: bottom $durationSlow $timing;
+  }
+
+  .answers-completed-inner {
+    $stopDim: 76px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    .checkmark-icon {
+      display: block;
+      width: $stopDim;
+      height: $stopDim;
+    }
+
+    .divider {
+      width: 3px;
+      height: $stopDim - 10px;
+      margin: 0 $minPadding;
+      background-color: $black;
+      border-radius: 2px;
+    }
+
+    p {
+      @include copyTertiary;
+      display: block;
+      flex-shrink: 2;
+      margin-bottom: 0;
+      font-size: 18px;
+    }
+  }
+
+  .close-button {
+    $dim: 36px;
+    position: absolute;
+    top: (-$dim / 3);
+    right: (-$dim / 3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: $dim;
+    height: $dim;
+    background-color: $black;
+    border: 0;
+    border-radius: 100%;
+
+    svg {
+      fill: $white;
+    }
+  }
+
+  a.next-link {
+    color: $black;
+    text-decoration: underline;
+  }
+}

--- a/src/components/site/answersCompletedAlert/index.jsx
+++ b/src/components/site/answersCompletedAlert/index.jsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'gatsby';
+import classnames from 'classnames';
+import CloseIcon from '../icons/Close.jsx';
+import CheckmarkIcon from '../icons/Checkmark.jsx';
+import {
+  answersCompleted,
+  answersCompletedInner,
+  closeButton,
+  showAnswersCompleted,
+  checkmarkIcon,
+  divider,
+  nextLink,
+} from './answers-completed.module.scss';
+
+const AnswersCompletedAlert = ({ showAlert, handleClose, nextUrl }) => {
+  const alertTimeout = useRef(null);
+
+  useEffect(() => {
+    if (showAlert) {
+      alertTimeout.current = setTimeout(handleClose, 5000);
+    } else {
+      clearTimeout(alertTimeout.current);
+    }
+  }, [showAlert]);
+
+  const alertClasses = classnames(answersCompleted, {
+    [showAnswersCompleted]: showAlert,
+  });
+
+  return (
+    <div className={alertClasses}>
+      <button type="button" className={closeButton} onClick={handleClose}>
+        <CloseIcon />
+      </button>
+      <div className={answersCompletedInner}>
+        <CheckmarkIcon className={checkmarkIcon} />
+        <div className={divider} />
+        <p>
+          You answered all of the questions on this page.{' '}
+          <Link className={nextLink} to={nextUrl}>
+            Go to the next page
+          </Link>{' '}
+          when you&apos;re ready.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+AnswersCompletedAlert.propTypes = {
+  showAlert: PropTypes.bool,
+  handleClose: PropTypes.func,
+  nextUrl: PropTypes.string,
+};
+
+export default AnswersCompletedAlert;

--- a/src/components/site/icons/Checkmark.jsx
+++ b/src/components/site/icons/Checkmark.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import SVGIcon from 'react-md/lib/SVGIcons/SVGIcon';
+import './icon.module.scss';
+
+const Checkmark = props => (
+  <SVGIcon {...props} role="presentation" viewBox="0 0 127 127">
+    <path
+      fill="#fff"
+      d="M63.5,0A63.5,63.5,0,1,0,127,63.5,63.5,63.5,0,0,0,63.5,0Z"
+    />
+    <path
+      fill="#1f2121"
+      d="M54.88,94.5,30.66,67.64,44.71,55,56,67.51l29.27-27.4L98.22,53.92Z"
+    />
+  </SVGIcon>
+);
+
+export default Checkmark;


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4648

## What this change does ##

This change adds a new all questions answered alert that notifies the student that all questions on the page have been answered and that they may continue onto the next page. This alert includes a close button and a 'go to next page' button.

## Notes for reviewers ##

Had to add a catch for this notification in the PageNav/index.jsx so that the modal could close. Also, I was able to add the 'go to next page' button into the modal by passing in the next page info into the new component.

Include an indication of how detailed a review you want on a 1-10 scale. - 5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"

## Testing ##

Answer all questions on the page and watch the magic!


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
![image](https://user-images.githubusercontent.com/8799443/116171935-9a709a80-a6be-11eb-8ed0-eba6f9bd823b.png)

