### PR TITLE
[EPO-4699] Move all alerts into NotificationsComponent

### DIFF
--- a/src/components/pageNav/index.jsx
+++ b/src/components/pageNav/index.jsx
@@ -7,14 +7,14 @@ import Button from '../site/button';
 import ButtonIcon from '../site/button/ButtonIcon';
 import ArrowLeft from '../site/icons/ArrowLeft';
 import ArrowRight from '../site/icons/ArrowRight';
-import AnswerRequiredAlert from '../site/answerRequiredAlert';
-import AnswersCompletedAlert from '../site/answersCompletedAlert';
+import Notification from '../site/notifications';
 import styles from './page-nav.module.scss';
 
 class PageNav extends React.PureComponent {
   constructor(props) {
     super(props);
 
+    this.answersRequiredText = 'All Answers Are Required';
     this.state = {
       showAllRequiredAlert: false,
       showCompletedAlert: false,
@@ -83,11 +83,19 @@ class PageNav extends React.PureComponent {
     return (
       <ButtonIcon
         srText={
-          allQuestionsAnswered ? title || 'Home' : 'All Answers Are Required'
+          allQuestionsAnswered ? title || 'Home' : this.answersRequiredText
         }
         Icon={ArrowRight}
       />
     );
+  }
+
+  getButtonTooltipLabel(type, title) {
+    const { allQuestionsAnswered } = this.props;
+    if (type === 'next') {
+      return allQuestionsAnswered ? title || 'Home' : this.answersRequiredText;
+    }
+    return title || 'Home';
   }
 
   renderNavItem(type, item, baseUrl, allQuestionsAnswered = false) {
@@ -128,7 +136,7 @@ class PageNav extends React.PureComponent {
         iconEl={this.getButtonIconEl(type, title)}
         onClick={isPrevOrAllQsA ? null : this.handleShowAllRequiredAlert}
         iconBefore={type === 'previous'}
-        tooltipLabel={item.title}
+        tooltipLabel={this.getButtonTooltipLabel(type, item.title)}
         tooltipPosition="top"
       />
     );
@@ -140,14 +148,20 @@ class PageNav extends React.PureComponent {
 
     return (
       <>
-        <AnswerRequiredAlert
-          showAlert={showAllRequiredAlert && !allQuestionsAnswered}
-          handleClose={this.handleHideAllRequiredAlert}
-        />
-        <AnswersCompletedAlert
-          showAlert={showCompletedAlert && allQuestionsAnswered}
+        <Notification
+          showAllRequiredAlert={
+            showAllRequiredAlert && allQuestionsAnswered
+              ? false
+              : showAllRequiredAlert
+          }
+          showCompletedAlert={
+            showCompletedAlert && !allQuestionsAnswered
+              ? false
+              : showCompletedAlert
+          }
           nextUrl={this.getNavLink('next', next, baseUrl)}
-          handleClose={this.handleHideCompletedAlert}
+          handleHideAllRequiredAlert={this.handleHideAllRequiredAlert}
+          handleHideCompletedAlert={this.handleHideCompletedAlert}
         />
         <div className={styles.pageNavigation}>
           <nav role="navigation" className={styles.navSecondary}>

--- a/src/components/site/notifications/alerts/answerRequiredAlert/answer-required.module.scss
+++ b/src/components/site/notifications/alerts/answerRequiredAlert/answer-required.module.scss
@@ -1,0 +1,66 @@
+.answer-required {
+  position: fixed;
+  bottom: -200px;
+  left: 50%;
+  z-index: 10;
+  display: inline-block;
+  max-width: 460px;
+  padding: $minPadding;
+  background-color: #ed4c4c;
+  border-radius: $minPadding;
+  transition: bottom $durationSuperSlow $timing;
+  transform: translateX(-50%);
+
+  &.show-answer-required {
+    bottom: $pageNavHeight + $minPadding;
+    transition: bottom $durationSlow $timing;
+  }
+
+  .answer-required-inner {
+    $stopDim: 76px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    .stop-icon {
+      display: block;
+      width: $stopDim;
+      height: $stopDim;
+    }
+
+    .divider {
+      width: 3px;
+      height: $stopDim - 10px;
+      margin: 0 $minPadding;
+      background-color: $black;
+      border-radius: 2px;
+    }
+
+    p {
+      @include copyTertiary;
+      display: block;
+      flex-shrink: 2;
+      margin-bottom: 0;
+      font-size: 18px;
+    }
+  }
+
+  .close-button {
+    $dim: 36px;
+    position: absolute;
+    top: (-$dim / 3);
+    right: (-$dim / 3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: $dim;
+    height: $dim;
+    background-color: $black;
+    border: 0;
+    border-radius: 100%;
+
+    svg {
+      fill: $white;
+    }
+  }
+}

--- a/src/components/site/notifications/alerts/answerRequiredAlert/index.jsx
+++ b/src/components/site/notifications/alerts/answerRequiredAlert/index.jsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import CloseIcon from '../../../icons/Close.jsx';
+import StopIcon from '../../../icons/Stop.jsx';
+import {
+  answerRequiredInner,
+  answerRequired,
+  closeButton,
+  showAnswerRequired,
+  stopIcon,
+  divider,
+} from './answer-required.module.scss';
+
+const AnswerRequiredAlert = ({ showAlert, handleClose }) => {
+  const alertTimeout = useRef(null);
+
+  useEffect(() => {
+    if (showAlert) {
+      alertTimeout.current = setTimeout(handleClose, 5000);
+    } else {
+      clearTimeout(alertTimeout.current);
+    }
+  }, [showAlert]);
+
+  const alertClasses = classnames(answerRequired, {
+    [showAnswerRequired]: showAlert,
+  });
+
+  return (
+    <div className={alertClasses}>
+      <button type="button" className={closeButton} onClick={handleClose}>
+        <CloseIcon />
+      </button>
+      <div className={answerRequiredInner}>
+        <StopIcon className={stopIcon} />
+        <div className={divider} />
+        <p>Please answer all questions before continuing to the next page.</p>
+      </div>
+    </div>
+  );
+};
+
+AnswerRequiredAlert.propTypes = {
+  showAlert: PropTypes.bool,
+  handleClose: PropTypes.func,
+};
+
+export default AnswerRequiredAlert;

--- a/src/components/site/notifications/alerts/answersCompletedAlert/answers-completed.module.scss
+++ b/src/components/site/notifications/alerts/answersCompletedAlert/answers-completed.module.scss
@@ -1,0 +1,72 @@
+.answers-completed {
+  position: fixed;
+  bottom: -200px;
+  left: 50%;
+  z-index: 10;
+  display: inline-block;
+  max-width: 460px;
+  padding: $minPadding;
+  background-color: #55da59;
+  border-radius: $minPadding;
+  transition: bottom $durationSuperSlow $timing;
+  transform: translateX(-50%);
+
+  &.show-answers-completed {
+    bottom: $pageNavHeight + $minPadding;
+    transition: bottom $durationSlow $timing;
+    transition-delay: 10s;
+  }
+
+  .answers-completed-inner {
+    $stopDim: 76px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    .checkmark-icon {
+      display: block;
+      width: $stopDim;
+      height: $stopDim;
+    }
+
+    .divider {
+      width: 3px;
+      height: $stopDim - 10px;
+      margin: 0 $minPadding;
+      background-color: $black;
+      border-radius: 2px;
+    }
+
+    p {
+      @include copyTertiary;
+      display: block;
+      flex-shrink: 2;
+      margin-bottom: 0;
+      font-size: 18px;
+    }
+  }
+
+  .close-button {
+    $dim: 36px;
+    position: absolute;
+    top: (-$dim / 3);
+    right: (-$dim / 3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: $dim;
+    height: $dim;
+    background-color: $black;
+    border: 0;
+    border-radius: 100%;
+
+    svg {
+      fill: $white;
+    }
+  }
+
+  a.next-link {
+    color: $black;
+    text-decoration: underline;
+  }
+}

--- a/src/components/site/notifications/alerts/answersCompletedAlert/index.jsx
+++ b/src/components/site/notifications/alerts/answersCompletedAlert/index.jsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'gatsby';
+import classnames from 'classnames';
+import CloseIcon from '../../../icons/Close.jsx';
+import CheckmarkIcon from '../../../icons/Checkmark.jsx';
+import {
+  answersCompleted,
+  answersCompletedInner,
+  closeButton,
+  showAnswersCompleted,
+  checkmarkIcon,
+  divider,
+  nextLink,
+} from './answers-completed.module.scss';
+
+const AnswersCompletedAlert = ({ showAlert, handleClose, nextUrl }) => {
+  const alertTimeout = useRef(null);
+  const delayTimeout = useRef(null);
+  const [delayedShow, setDelayedShow] = useState(false);
+
+  useEffect(() => {
+    if (showAlert) {
+      clearTimeout(delayTimeout.current);
+      delayTimeout.current = setTimeout(() => {
+        setDelayedShow(true);
+      }, 15000);
+    } else {
+      setDelayedShow(false);
+      clearTimeout(delayTimeout.current);
+    }
+  }, [showAlert]);
+
+  useEffect(() => {
+    if (delayedShow) {
+      clearTimeout(alertTimeout.current);
+      alertTimeout.current = setTimeout(handleClose, 8000);
+    } else {
+      clearTimeout(alertTimeout.current);
+    }
+  }, [delayedShow]);
+
+  const alertClasses = classnames(answersCompleted, {
+    [showAnswersCompleted]: showAlert,
+  });
+
+  return (
+    <div className={alertClasses}>
+      <button type="button" className={closeButton} onClick={handleClose}>
+        <CloseIcon />
+      </button>
+      <div className={answersCompletedInner}>
+        <CheckmarkIcon className={checkmarkIcon} />
+        <div className={divider} />
+        <p>
+          You answered all of the questions on this page.{' '}
+          <Link className={nextLink} to={nextUrl}>
+            Go to the next page
+          </Link>{' '}
+          when you&apos;re ready.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+AnswersCompletedAlert.propTypes = {
+  showAlert: PropTypes.bool,
+  handleClose: PropTypes.func,
+  nextUrl: PropTypes.string,
+};
+
+export default AnswersCompletedAlert;

--- a/src/components/site/notifications/index.jsx
+++ b/src/components/site/notifications/index.jsx
@@ -1,0 +1,41 @@
+/* eslint-disable react/jsx-handler-names */
+import React from 'react';
+import PropTypes from 'prop-types';
+import AnswerRequiredAlert from './alerts/answerRequiredAlert';
+import AnswersCompletedAlert from './alerts/answersCompletedAlert';
+
+class Notifications extends React.PureComponent {
+  render() {
+    const {
+      showAllRequiredAlert,
+      showCompletedAlert,
+      nextUrl,
+      handleHideAllRequiredAlert,
+      handleHideCompletedAlert,
+    } = this.props;
+
+    return (
+      <>
+        <AnswerRequiredAlert
+          showAlert={showAllRequiredAlert}
+          handleClose={handleHideAllRequiredAlert}
+        />
+        <AnswersCompletedAlert
+          showAlert={showCompletedAlert}
+          nextUrl={nextUrl}
+          handleClose={handleHideCompletedAlert}
+        />
+      </>
+    );
+  }
+}
+
+export default Notifications;
+
+Notifications.propTypes = {
+  showAllRequiredAlert: PropTypes.bool,
+  showCompletedAlert: PropTypes.bool,
+  nextUrl: PropTypes.string,
+  handleHideAllRequiredAlert: PropTypes.func,
+  handleHideCompletedAlert: PropTypes.func,
+};


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4699

## What this change does ##

This change moves all alerts into a central component called `NotificationsComponent`.

## Notes for reviewers ##

I had to reverse the logic in the PageContainer to return `true` if no questions are present and `true` by default. It will then return `false` if any question is unanswered. This precipitated down into the pageNav component.

Include an indication of how detailed a review you want on a 1-10 scale. - 5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"

## Testing ##

n/a


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
n/a
