### PR TITLE
[EPO-4712] Add dataset color matching in scatter plots

### DIFF
--- a/src/assets/stylesheets/STACSS/_appearance.scss
+++ b/src/assets/stylesheets/STACSS/_appearance.scss
@@ -116,7 +116,6 @@
   margin-bottom: $verticalSpace;
 }
 
-
 .equation {
   font-size: 17px;
   font-weight: $medium;

--- a/src/assets/stylesheets/_variables.scss
+++ b/src/assets/stylesheets/_variables.scss
@@ -150,7 +150,7 @@ $verticalSpace: $baseLineHeight * 1em;
 $headingWithSpaceHeight: 90px;
 $tallestSquareWidget: calc(
   100vh - #{$pageNavHeight} - #{$siteHeaderHeight} - #{$headingWithSpaceHeight} -
-  #{$minPadding}
+    #{$minPadding}
 );
 
 // $durationFast: 0.1s;

--- a/src/components/charts/galacticProperties/galactic-properties.module.scss
+++ b/src/components/charts/galacticProperties/galactic-properties.module.scss
@@ -19,7 +19,8 @@
 
 .group-point {
   stroke: none;
-  transition: fill $timing $duration, stroke $timing $duration, opacity $timing $duration;
+  transition: fill $timing $duration, stroke $timing $duration,
+    opacity $timing $duration;
 }
 
 .invisible {
@@ -33,71 +34,124 @@
 }
 
 // mini drawer
-aside {
-  .property-item {
-    margin-bottom: -1px;
-    background-color: $neutral10;
-    transition: background-color $timing $duration;
+aside .property-item {
+  margin-bottom: -1px;
+  background-color: $neutral10;
+  transition: background-color $timing $duration;
+
+  .nav-avatar {
+    @include labelPrimary;
+    font-weight: $medium;
+  }
+
+  $i: 0;
+  @each $color in $chartColors {
+    &.inactive-#{$i} {
+      .nav-avatar {
+        color: $color;
+      }
+
+      :global .md-icon {
+        fill: $color;
+      }
+    }
+
+    &.active-#{$i} {
+      background-color: $color;
+
+      .nav-avatar {
+        color: $white;
+      }
+
+      :global {
+        .md-icon {
+          fill: $white;
+        }
+      }
+    }
+
+    &.inactive-#{$i},
+    &.active-#{$i} {
+      &:hover {
+        background-color: $color;
+
+        .nav-avatar {
+          color: $white;
+        }
+
+        :global .md-icon {
+          fill: $white;
+        }
+      }
+    }
+    $i: $i + 1;
+  }
+
+  &.link-is-disabled {
+    background-color: rgba(200, 200, 200, 0.6);
 
     .nav-avatar {
-      @include labelPrimary;
-      font-weight: $medium;
-      color: $basePrimary;
-    }
-
-    :global {
-      .md-icon {
-        fill: $basePrimary;
-      }
-    }
-
-    &:hover {
-      background-color: $basePrimary;
-
-      .nav-avatar {
-        color: $white;
-      }
-    }
-
-    &.link-active {
-      background-color: $basePrimary;
-
-      .nav-avatar {
-        color: $white;
-      }
-    }
-
-    &.link-is-disabled {
-      background-color: rgba(200, 200, 200, 0.6);
-
-      .nav-avatar {
-        color: $neutral10;
-      }
+      color: $neutral10;
     }
   }
 }
 
 // full size drawer
-nav {
-  .property-item {
-    :global {
-      .md-text {
-        @include labelPrimary;
-        font-weight: $medium;
+nav .property-item {
+  :global {
+    .md-text {
+      @include labelPrimary;
+      font-weight: $medium;
+    }
+  }
+
+  $i: 0;
+  @each $color in $chartColors {
+    &.inactive-#{$i} {
+      svg {
+        fill: $color;
+      }
+
+      :global {
+        .md-text {
+          /* stylelint-disable-next-line declaration-no-important */
+          color: $color !important;
+        }
       }
     }
 
-    &.link-active {
-      background-color: $basePrimary;
+    &.active-#{$i},
+    &.active-#{$i}:hover,
+    &.inactive-#{$i}:hover {
+      /* stylelint-disable-next-line declaration-no-important */
+      background-color: $color !important;
+
+      svg {
+        fill: $white;
+      }
+
+      > div {
+        /* stylelint-disable-next-line declaration-no-important */
+        background-color: $color !important;
+      }
 
       :global {
         .md-tile-text--primary,
-        .md-tile-text--primary.md-text--theme-primary,
+        .md-tile-text--primary.md-text,
         .md-text {
           /* stylelint-disable-next-line declaration-no-important */
           color: $white !important;
         }
       }
+    }
+    $i: $i + 1;
+  }
+
+  &.link-is-disabled {
+    background-color: rgba(200, 200, 200, 0.6);
+
+    .nav-avatar {
+      color: $neutral10;
     }
   }
 }

--- a/src/components/charts/galacticProperties/index.jsx
+++ b/src/components/charts/galacticProperties/index.jsx
@@ -406,7 +406,7 @@ class GalacticProperties extends React.Component {
                     offsetTop,
                   }}
                   pointClasses={classnames(styles.groupPoint, {
-                    'color-1-fill': yValueAccessor !== 'color',
+                    'color-0-fill': yValueAccessor !== 'color',
                   })}
                 />
               )}

--- a/src/containers/GalacticPropertiesComboContainer.jsx
+++ b/src/containers/GalacticPropertiesComboContainer.jsx
@@ -6,11 +6,7 @@ import API from '../lib/API.js';
 import NavDrawer from '../components/charts/shared/navDrawer/index.jsx';
 import GalacticProperties from '../components/charts/galacticProperties/index.jsx';
 import ScatterPlot from '../components/site/icons/Star';
-import {
-  card,
-  linkActive,
-  propertyItem,
-} from '../components/charts/galacticProperties/galactic-properties.module.scss';
+import style from '../components/charts/galacticProperties/galactic-properties.module.scss';
 import { paddedDrawerInner } from '../components/charts/shared/navDrawer/nav-drawer.module.scss';
 
 class GalacticPropertiesComboContainer extends React.PureComponent {
@@ -20,7 +16,6 @@ class GalacticPropertiesComboContainer extends React.PureComponent {
     this.properties = [
       {
         name: 'Brightness vs Distance',
-        color: 'rgb(254, 216, 40)',
         options: {
           title: 'Brightness Vs Distance',
           xAxisLabel: 'Distance (Billion Ly)',
@@ -36,7 +31,6 @@ class GalacticPropertiesComboContainer extends React.PureComponent {
       },
       {
         name: 'Color vs Distance',
-        color: 'rgb(26, 181, 121)',
         options: {
           title: 'Color Vs Distance',
           xAxisLabel: 'Distance (Billion Ly)',
@@ -99,18 +93,20 @@ class GalacticPropertiesComboContainer extends React.PureComponent {
   };
 
   generateNavItems(properties, activeProperty) {
-    return properties.map(property => {
-      const { name, color } = property;
+    return properties.map((property, i) => {
+      const { name } = property;
+      const isActive = activeProperty === property;
       return {
         leftAvatar: (
           <span>
-            <ScatterPlot style={{ fill: color }} />
+            <ScatterPlot />
             <span className="screen-reader-only">{name}</span>
           </span>
         ),
         primaryText: name,
-        className: classnames(propertyItem, {
-          [linkActive]: activeProperty === property,
+        className: classnames(style.propertyItem, {
+          [style[`inactive${i}`]]: !isActive,
+          [style[`active${i}`]]: isActive,
         }),
         onClick: () => this.setActiveProperty(property),
       };
@@ -135,7 +131,7 @@ class GalacticPropertiesComboContainer extends React.PureComponent {
     return (
       <NavDrawer
         interactableToolbar
-        cardClasses={card}
+        cardClasses={style.card}
         contentClasses={paddedDrawerInner}
         navItems={navItems}
         toolbarTitle={title}
@@ -145,6 +141,7 @@ class GalacticPropertiesComboContainer extends React.PureComponent {
             <GalacticProperties
               className="color-brightness-vs-distance-combo"
               options={activeProperty.options}
+              color={activeProperty.color}
               {...{
                 data,
                 xAxisLabel,


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4712

## What this change does ##

This change applies the same dataset color logic as the Galaxy/Hubble Plot selector widget to the galactic properties widget in order to automate the dataset color relationship.

## Notes for reviewers ##

This change primary resides in the `galactic-properties.module.scss` in more 'generic' classes (`&.inactive-#{$i}` and `&.active-#{$i}`). These two classes' styling trickles down to style their svgs, background-colors, and text according to the defined `$chartColors` found in the `_variables.scss`.

Include an indication of how detailed a review you want on a 1-10 scale. - 5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"

## Testing ##

n/a


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
![2021-05-17_17-24-25 (1)](https://user-images.githubusercontent.com/8799443/118572271-df737400-b734-11eb-88e1-1ec1974ef6ba.gif)

### After:
![2021-05-17_17-21-22 (1)](https://user-images.githubusercontent.com/8799443/118572085-6e33c100-b734-11eb-859d-92843afd057f.gif)
