### PR TITLE
[EPO-4715] Add new Scientific Notation function

### DIFF
--- a/src/components/charts/shared/StellarValue.jsx
+++ b/src/components/charts/shared/StellarValue.jsx
@@ -15,7 +15,14 @@ class StellarValue extends React.PureComponent {
 
     return (
       <>
-        {!isSvg && <span>{formatted}</span>}
+        {!isSvg &&
+          // eslint-disable-next-line no-underscore-dangle
+          (formatted.__html ? (
+            // eslint-disable-next-line react/no-danger
+            <span dangerouslySetInnerHTML={formatted} />
+          ) : (
+            <span>{formatted}</span>
+          ))}
         {isSvg && <tspan>{formatted}</tspan>}
         {formatted && <Unit type={type} isSvg={isSvg} />}
       </>

--- a/src/components/qas/questions/qaCalculator/equations/FindKineticEnergy.jsx
+++ b/src/components/qas/questions/qaCalculator/equations/FindKineticEnergy.jsx
@@ -2,7 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { QACalculatorIconUnit } from '../qQaCalculatorIcons.jsx';
-import { addTheCommas, toSigFigs } from '../../../../../lib/utilities.js';
+import {
+  addTheCommas,
+  scientificNotation,
+} from '../../../../../lib/utilities.js';
 import {
   color,
   equation,
@@ -54,7 +57,10 @@ export default function FindKineticEnergy(props) {
       <span className={addColorClass}>
         {kineticEnergy ? (
           <span>
-            {addTheCommas(toSigFigs(+kineticEnergy, 3))}
+            <span
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={scientificNotation(+kineticEnergy, 3)}
+            ></span>
             <QACalculatorIconUnit
               className={addColorClass}
               unit="kineticEnergy"

--- a/src/lib/utilities.js
+++ b/src/lib/utilities.js
@@ -238,6 +238,27 @@ export const toSigFigs = (number, precision) => {
   return String(roundedValue);
 };
 
+export const scientificNotation = (number, precision, returnHtml = true) => {
+  if (number === 0) return 0;
+
+  const [val, exp] = Number.parseFloat(number)
+    .toExponential()
+    .split('e');
+
+  const numPlaces = Math.abs(+exp);
+
+  if ((Math.abs(number) < 1 && numPlaces > 3) || numPlaces > 9) {
+    const coefficientAndBase = `${parseFloat(toSigFigs(+val, precision))} x 10`;
+
+    return returnHtml
+      ? renderDef(`${coefficientAndBase}<sup>${+exp}</sup>`)
+      : `${coefficientAndBase}^${+exp}`;
+  }
+
+  const sigFigged = addTheCommas(toSigFigs(number, precision));
+  return returnHtml ? renderDef(sigFigged) : sigFigged;
+};
+
 const getDamageDescription = function(data) {
   if (!data) return null;
   return data.description;
@@ -282,7 +303,7 @@ export const getValue = function(accessor, data) {
       craterDepth: addTheCommas(toSigFigs(data, 3)),
       count: addTheCommas(formatValue(data ? data.length : 0, 0)),
       countOfTotal: getCountOutOfTotal(data),
-      kineticEnergy: addTheCommas(toSigFigs(+data, 3)),
+      kineticEnergy: scientificNotation(+data, 3),
       volume: toSigFigs(data, 4),
       overPressure: addTheCommas(toSigFigs(data, 3)),
       mercalliIntensity: getDamageDescription(data),


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4715

## What this change does ##

This change adds the `scientificNotation()` into the mix. This function will convert the value given into scientific notation through a specified sigFig. If no sigFig is specified, then it defualts to 3. If the number is greater than 1 or less than -1 and has 9 or fewer digits or if the number is between 1 and -1 and has 3 or fewer digits after the decimal the function will return that number rounded to sig figs.

## Notes for reviewers ##

Added the ability for the table cell to render the HTML if present.

Include an indication of how detailed a review you want on a 1-10 scale. - 5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"

## Testing ##

n/a


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [ ] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
![image](https://user-images.githubusercontent.com/8799443/119903997-7511bf00-befe-11eb-93a2-f368de61bd0b.png)

### After:
![image](https://user-images.githubusercontent.com/8799443/119905380-04b86d00-bf01-11eb-91a7-ebe8384f82ed.png)

