### PR TITLE
[EPO-4804] Change MathJax svg font to 18px and keep max-width

### DIFF
--- a/src/components/site/mathJax/mathJax.module.scss
+++ b/src/components/site/mathJax/mathJax.module.scss
@@ -4,5 +4,6 @@
 
   svg {
     max-width: 100%;
+    font-size: 18px;
   }
 }


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4804

## What this change does ##

After trying a few solutions I've ended up on a suggestion by Blake. As of now, the svg within the MathJax component is only allowed to stretch to its container's width. In keeping with this logic (as we do not want the equation to every "overflow" its container), I'm implementing the suggestion from Blake to adjust the font size of the svg itself in the css. If the font size is 18px it should address the font size being larger than the standard copy on the page (which, I believe is 16px). 18px is neither too small nor too large in comparison copy on page and will certainly suit the needs of this ticket. Also having the svg not "overflow" its bounds (parent container) the font will scale as needed when additional space is required in the equation.

## Notes for reviewers ##

n/a

Include an indication of how detailed a review you want on a 1-10 scale. - 1 = "I barely need review on this"

## Testing ##

n/a


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### After:
![image](https://user-images.githubusercontent.com/8799443/121269843-623fa880-c875-11eb-86c7-69377136f4cc.png)

