### PR TITLE
[EPO-4839] Add loop option for blink animation

### DIFF
--- a/src/components/charts/galaxySelector/index.jsx
+++ b/src/components/charts/galaxySelector/index.jsx
@@ -209,8 +209,16 @@ class GalaxySelector extends React.PureComponent {
   }
 
   nextBlink = () => {
-    const { blinkCallback, images } = this.props;
-    blinkCallback(this.getBlink(images, 1));
+    const { blinkCallback, images, loop } = this.props;
+
+    const nextBlink = this.getBlink(images, 1);
+    const { activeImageIndex: nextActiveImageIndex } = nextBlink || {};
+
+    if (loop === false && nextActiveImageIndex === images.length - 1) {
+      this.stopBlink();
+    }
+
+    blinkCallback(nextBlink);
   };
 
   previousBlink = () => {
@@ -453,6 +461,7 @@ GalaxySelector.propTypes = {
   name: PropTypes.string,
   color: PropTypes.string,
   autoplay: PropTypes.bool,
+  loop: PropTypes.bool,
   selectionCallback: PropTypes.func,
   blinkCallback: PropTypes.func,
 };

--- a/src/containers/SupernovaSelectorWithLightCurveContainer.jsx
+++ b/src/containers/SupernovaSelectorWithLightCurveContainer.jsx
@@ -179,6 +179,7 @@ class SupernovaSelectorWithLightCurveContainer extends React.PureComponent {
     } = this.props;
     const {
       autoplay,
+      loop,
       showSelector,
       showLightCurve,
       lightCurveTemplates,
@@ -225,6 +226,7 @@ class SupernovaSelectorWithLightCurveContainer extends React.PureComponent {
               <SupernovaSelector
                 className={`supernova-selector-${name}`}
                 autoplay={autoplay && !selectedData}
+                loop={loop}
                 {...{ selectedData, activeGalaxy, preSelected }}
                 data={getSupernovaPointData(activeGalaxy)}
                 alerts={activeGalaxy ? activeGalaxy.alerts : []}

--- a/src/data/pages/blinking-supernovae.json
+++ b/src/data/pages/blinking-supernovae.json
@@ -22,7 +22,8 @@
         "showSelector": true,
         "toggleDataPointsVisibility": "50",
         "legend": false,
-        "autoplay": true
+        "autoplay": true,
+        "loop": false
       }
     }
   ],

--- a/src/data/pages/searching-for-supernovae-1.json
+++ b/src/data/pages/searching-for-supernovae-1.json
@@ -21,9 +21,9 @@
       "options": {
         "showSelector": true,
         "showLightCurve": false,
-        "autoplay": false,
         "toggleDataPointsVisibility": "90",
-        "autoplay": true
+        "autoplay": true,
+        "loop": false
       }
     }
   ],

--- a/src/data/pages/searching-for-supernovae-2.json
+++ b/src/data/pages/searching-for-supernovae-2.json
@@ -20,7 +20,8 @@
       "options": {
         "showSelector": true,
         "toggleDataPointsVisibility": "59",
-        "autoplay": true
+        "autoplay": true,
+        "loop": false
       }
     }
   ],

--- a/src/data/pages/searching-for-supernovae-3.json
+++ b/src/data/pages/searching-for-supernovae-3.json
@@ -20,7 +20,8 @@
       "options": {
         "showSelector": true,
         "toggleDataPointsVisibility": "60",
-        "autoplay": true
+        "autoplay": true,
+        "loop": false
       }
     }
   ],

--- a/src/fragments/widgetOptions.js
+++ b/src/fragments/widgetOptions.js
@@ -38,6 +38,7 @@ export const widgetOptionsFragment = graphql`
     hideImage
     randomSource
     autoplay
+    loop
     preSelected
     multiple
     svgShapes


### PR DESCRIPTION
- Ensures autoplay functionality still works
- Sets new loop prop default to `true`
- When loop is `false` animation will stop ready to start again
  from first frame

JIRA: https://jira.lsstcorp.org/browse/EPO-4839

## What this change does ##

This change adds the `loopAnimation` option in the json data and its defaultProp is set to `true`. If `loopAnimation` is set to `false`, the animation will play to the end and stop. When the play button is triggered again the animation will begin from the first frame.

## Notes for reviewers ##

n/a

Include an indication of how detailed a review you want on a 1-10 scale. - 5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"

## Testing ##

n/a


## Checklist ##

If any of the following are true, please check them off
- [x] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
![2021-06-08_10-30-29 (1)](https://user-images.githubusercontent.com/8799443/122317801-f2639a80-ced2-11eb-82e4-8b335b75eaf5.gif)

### After:
![2021-06-16_18-45-42 (1)](https://user-images.githubusercontent.com/8799443/122317937-28088380-ced3-11eb-84f4-9f8a2d0dcdd9.gif)

