### PR TITLE
[EPO-4840] Add the Elapsed Time indicator

### DIFF
--- a/src/assets/stylesheets/_variables.scss
+++ b/src/assets/stylesheets/_variables.scss
@@ -164,7 +164,7 @@ $verticalSpace: $baseLineHeight * 1em;
 $headingWithSpaceHeight: 90px;
 $tallestSquareWidget: calc(
   100vh - #{$pageNavHeight} - #{$siteHeaderHeight} - #{$headingWithSpaceHeight} -
-    #{$minPadding}
+  #{$minPadding}
 );
 
 // $durationFast: 0.1s;

--- a/src/components/charts/galaxySelector/index.jsx
+++ b/src/components/charts/galaxySelector/index.jsx
@@ -10,6 +10,7 @@ import CircularProgress from 'react-md/lib/Progress/CircularProgress';
 import { arrayify } from '../../../lib/utilities.js';
 import { getAlertFromImageId } from './galaxySelectorUtilities.js';
 import Blinker from '../shared/blinker/index.jsx';
+import ElapsedTime from '../shared/elapsedTime/index.jsx';
 import Points from './Points';
 import Message from './Message';
 import Legend from '../shared/legend/index.jsx';
@@ -317,6 +318,16 @@ class GalaxySelector extends React.PureComponent {
     }));
   };
 
+  getAlertDaysAndHours = (id, alerts) => {
+    const currentAlert = getAlertFromImageId(id, alerts);
+    const dateDiff = currentAlert.date - alerts[0].date;
+
+    return {
+      days: Math.round(dateDiff),
+      hours: Math.round((24 / dateDiff) % 24),
+    };
+  };
+
   render() {
     const {
       data,
@@ -331,6 +342,7 @@ class GalaxySelector extends React.PureComponent {
       legend,
       activeImageId,
       activeGalaxy,
+      alerts,
       selectedData: selectedDataProp,
       color,
     } = this.props;
@@ -414,14 +426,21 @@ class GalaxySelector extends React.PureComponent {
               alt={image.altText}
             />
           ) : (
-            <Blinker
-              images={images}
-              activeId={activeImageId}
-              playing={playing}
-              handleStartStop={this.startStopBlink}
-              handleNext={this.onNextBlink}
-              handlePrevious={this.onPreviousBlink}
-            />
+            <>
+              <Blinker
+                images={images}
+                activeId={activeImageId}
+                playing={playing}
+                handleStartStop={this.startStopBlink}
+                handleNext={this.onNextBlink}
+                handlePrevious={this.onPreviousBlink}
+              />
+              {alerts && (
+                <ElapsedTime
+                  {...this.getAlertDaysAndHours(activeImageId, alerts)}
+                />
+              )}
+            </>
           )}
         </div>
       </>

--- a/src/components/charts/shared/elapsedTime/elapsedTime.module.scss
+++ b/src/components/charts/shared/elapsedTime/elapsedTime.module.scss
@@ -1,0 +1,48 @@
+$padding: $minPadding / 2.3;
+
+.elapsed-time-container {
+  position: absolute;
+  right: $minPadding;
+  bottom: $minPadding;
+  z-index: 2;
+
+  background-color: $white;
+  border-radius: $padding;
+
+  .header {
+    padding: $padding;
+    border-bottom: 1px solid $black;
+  }
+
+  .panel-container {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+
+    .left-panel {
+      border-right: 1px solid $black;
+    }
+
+    .left-panel,
+    .right-panel {
+      display: flex;
+      flex-flow: column nowrap;
+      align-items: center;
+      justify-content: space-between;
+      width: 50%;
+      padding: $padding;
+
+      .number {
+        display: flex;
+        flex: 1;
+        font-size: 1.4rem;
+      }
+
+      .text {
+        font-size: 0.9rem;
+      }
+    }
+  }
+}

--- a/src/components/charts/shared/elapsedTime/index.jsx
+++ b/src/components/charts/shared/elapsedTime/index.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './elapsedTime.module.scss';
+
+const ElapsedTime = ({ days, hours }) => {
+  return (
+    <div className={styles.elapsedTimeContainer}>
+      <div className={styles.header}>Elapsed Time</div>
+      <div className={styles.panelContainer}>
+        <div className={styles.leftPanel}>
+          <span className={styles.number}>{days || 0}</span>
+          <span className={styles.text}>Days</span>
+        </div>
+        <div className={styles.rightPanel}>
+          <span className={styles.number}>{hours || 0}</span>
+          <span className={styles.text}>Hours</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+ElapsedTime.propTypes = {
+  days: PropTypes.number,
+  hours: PropTypes.number,
+};
+
+export default ElapsedTime;

--- a/src/data/pages/searching-for-supernovae-1.json
+++ b/src/data/pages/searching-for-supernovae-1.json
@@ -23,7 +23,7 @@
         "showLightCurve": false,
         "toggleDataPointsVisibility": "90",
         "autoplay": true,
-        "loop": false
+        "loop": true
       }
     }
   ],


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4840

## What this change does ##

This change adds the Elapsed Time indicator to the Galaxy selector widget that displays the elapsed days and hours of each alert. The indicator is its own separate component that takes two props, days and hours. 

## Notes for reviewers ##

n/a

Include an indication of how detailed a review you want on a 1-10 scale. - 5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"

## Testing ##

n/a


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
![2021-06-16_18-45-42 (1)](https://user-images.githubusercontent.com/8799443/122623389-b6eeda80-d050-11eb-96bc-e7533cf77b09.gif)

### After:
![2021-06-18_16-50-55 (1)](https://user-images.githubusercontent.com/8799443/122624921-45fef100-d057-11eb-8b15-c37960e1adc5.gif)


