### PR TITLE
[EPO-4842] Updated QA Review page per Ardis direction

### DIFF
--- a/src/components/charts/galacticProperties/LegendMultiple.jsx
+++ b/src/components/charts/galacticProperties/LegendMultiple.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Card from '../../site/card/index.js';
-import { getFluxRgba } from './galacticPropertiesUtilities.js';
 import styles from './galactic-properties.module.scss';
 
 class LegendMultiple extends React.PureComponent {

--- a/src/components/charts/galacticProperties/Points.jsx
+++ b/src/components/charts/galacticProperties/Points.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import find from 'lodash/find';
 import classnames from 'classnames';
 import Point from '../shared/shapes';
-import { getFluxRgba } from './galacticPropertiesUtilities.js';
 import { invisible } from './galactic-properties.module.scss';
 
 const dimension = 20;
@@ -27,7 +26,7 @@ class Points extends React.PureComponent {
     return (
       <g className="data-points">
         {data.map((d, i) => {
-          const { id, name, label, color, use_color: useColor } = d;
+          const { id, name, label, use_color: useColor } = d;
           const key = `point-${id}-${i}`;
           const useFluxColor = yValueAccessor === 'color';
           const selected = !!find(selectedData, { id });

--- a/src/components/qas/index.jsx
+++ b/src/components/qas/index.jsx
@@ -13,6 +13,7 @@ class QAs extends React.PureComponent {
       updateAnswer,
       advanceActiveQuestion,
       setActiveQuestion,
+      qaReviewPage,
     } = this.props;
 
     return (
@@ -20,8 +21,10 @@ class QAs extends React.PureComponent {
         {questions.map(question => {
           const { question: q, number } = question;
           const primeQ = q[0];
-          const { id, questionType } = primeQ;
+          const { id, questionType, qaReview } = primeQ;
           const key = `qa-${id}`;
+
+          if (qaReviewPage && !qaReview) return false;
 
           if (q.length > 1) {
             return (
@@ -66,6 +69,7 @@ QAs.propTypes = {
   updateAnswer: PropTypes.func,
   advanceActiveQuestion: PropTypes.func,
   setActiveQuestion: PropTypes.func,
+  qaReviewPage: PropTypes.bool,
 };
 
 export default QAs;

--- a/src/components/qas/questions/qaCalculator/equations/FindMass.jsx
+++ b/src/components/qas/questions/qaCalculator/equations/FindMass.jsx
@@ -13,7 +13,7 @@ import {
 } from '../../../../site/mathJax/mathjax.utilities.js';
 
 export default function FindMass(props) {
-  const { density, mass, diameter, qaReview } = props;
+  const { density, mass, diameter } = props;
 
   const p = !density
     ? colorize(`\\rho`)
@@ -39,5 +39,4 @@ FindMass.propTypes = {
   density: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   mass: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   diameter: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  qaReview: PropTypes.bool,
 };

--- a/src/containers/QAReviewContainer.jsx
+++ b/src/containers/QAReviewContainer.jsx
@@ -52,7 +52,8 @@ class QAReviewContainer extends React.PureComponent {
   reviewifyQuestion(question, questionNumbers, pageId, qIndex) {
     question.number = questionNumbers[qIndex];
     question.question.forEach(q => {
-      q.qaReview = true;
+      const { qaReview } = q;
+      q.qaReview = qaReview !== null ? qaReview : true;
     });
 
     return question;
@@ -188,7 +189,7 @@ class QAReviewContainer extends React.PureComponent {
                   <div key={`page-${page.id}`} className={qaReviewPage}>
                     {questions && (
                       <div className={qaReviewQuestionsContainer}>
-                        <QAs {...shared} />
+                        <QAs {...shared} qaReviewPage />
                       </div>
                     )}
                     {questions &&

--- a/src/containers/SupernovaSelectorWithLightCurveContainer.jsx
+++ b/src/containers/SupernovaSelectorWithLightCurveContainer.jsx
@@ -280,10 +280,10 @@ class SupernovaSelectorWithLightCurveContainer extends React.PureComponent {
                   activeAlert ? activeAlert.alert_id.toString() : null
                 }
                 interactableTemplates={
-                  activeQuestionId && activeQuestionId === templateAnswerId
+                  !!activeQuestionId && activeQuestionId === templateAnswerId
                 }
                 interactablePeakMag={
-                  activeQuestionId && peakMagAnswerId === activeQuestionId
+                  !!activeQuestionId && peakMagAnswerId === activeQuestionId
                 }
                 pointsAreVisible={
                   selectorQId ? !isEmpty(answers[selectorQId]) : true

--- a/src/data/pages/blinking-supernovae.json
+++ b/src/data/pages/blinking-supernovae.json
@@ -1,7 +1,7 @@
 {
-  "id": "3",
+  "id": "02",
   "investigation": "exploding-stars",
-  "order": "03",
+  "order": "02",
   "title": "Blinking Supernovae",
   "slug": "blinking-supernovae/",
   "previous": {
@@ -23,7 +23,8 @@
         "toggleDataPointsVisibility": "50",
         "legend": false,
         "autoplay": true,
-        "loop": false
+        "loop": false,
+        "qaReview": false
       }
     }
   ],
@@ -37,7 +38,8 @@
           "title": "Question #1",
           "label": "<p>Click on a point on the Image to select the supernova</p>",
           "answerPre": "<span>Selected Supernova: </span>",
-          "answerAccessor": "supernova"
+          "answerAccessor": "supernova",
+          "qaReview": false
         }
       ]
     }

--- a/src/data/pages/classifying-supernovae-ia.json
+++ b/src/data/pages/classifying-supernovae-ia.json
@@ -1,7 +1,7 @@
 {
-  "id": "7",
+  "id": "05",
   "investigation": "exploding-stars",
-  "order": "08",
+  "order": "05",
   "title": "Type Ia Supernovae",
   "slug": "classifying-supernovae-ia/",
   "previous": {

--- a/src/data/pages/classifying-supernovae-iip.json
+++ b/src/data/pages/classifying-supernovae-iip.json
@@ -1,7 +1,7 @@
 {
-  "id": "6",
+  "id": "04",
   "investigation": "exploding-stars",
-  "order": "07",
+  "order": "04",
   "title": "Type IIp Supernovae",
   "slug": "classifying-supernovae-iip/",
   "previous": {

--- a/src/data/pages/classifying-supernovae-light-curves.json
+++ b/src/data/pages/classifying-supernovae-light-curves.json
@@ -1,7 +1,7 @@
 {
-  "id": "8",
+  "id": "06",
   "investigation": "exploding-stars",
-  "order": "09",
+  "order": "06",
   "title": "Using Light Curves to Classify Supernovae",
   "slug": "classifying-supernovae-light-curves/",
   "previous": {
@@ -73,7 +73,7 @@
     {
       "question": [
         {
-          "id": "530",
+          "id": "54",
           "questionType": "select",
           "tool": "selection",
           "title": "Question #1",

--- a/src/data/pages/discovering-supernovae.json
+++ b/src/data/pages/discovering-supernovae.json
@@ -1,5 +1,5 @@
 {
-  "id": "2",
+  "id": "01",
   "investigation": "exploding-stars",
   "order": "01",
   "title": "Discovering Supernovae",

--- a/src/data/pages/discuss-report.json
+++ b/src/data/pages/discuss-report.json
@@ -1,7 +1,7 @@
 {
   "id": "17",
   "investigation": "exploding-stars",
-  "order": "22",
+  "order": "17",
   "title": "Reflect and Discuss",
   "slug": "discuss-report/",
   "previous": {
@@ -40,7 +40,8 @@
           { "accessor": "magnitude", "id": "165" },
           { "accessor": "megaLightYears", "id": "68" }
         ]
-      ]
+      ],
+      "qaReview": false
     }
   ],
   "questionsByPage": [

--- a/src/data/pages/distance-to-supernovae-1-1.json
+++ b/src/data/pages/distance-to-supernovae-1-1.json
@@ -1,7 +1,7 @@
 {
-  "id": "24",
+  "id": "13",
   "investigation": "exploding-stars",
-  "order": "17",
+  "order": "13",
   "title": "Determining the Peak Apparent Magnitude of Supernova #5",
   "slug": "distance-to-supernovae-1-1/",
   "previous": {

--- a/src/data/pages/distance-to-supernovae-1-2.json
+++ b/src/data/pages/distance-to-supernovae-1-2.json
@@ -1,7 +1,7 @@
 {
-  "id": "25",
+  "id": "14a",
   "investigation": "exploding-stars",
-  "order": "18a",
+  "order": "14.1",
   "title": "Determining the Peak Apparent Magnitude of Supernova #6",
   "slug": "distance-to-supernovae-1-2/",
   "previous": {

--- a/src/data/pages/distance-to-supernovae-1-3.json
+++ b/src/data/pages/distance-to-supernovae-1-3.json
@@ -1,7 +1,7 @@
 {
-  "id": "26",
+  "id": "14b",
   "investigation": "exploding-stars",
-  "order": "18b",
+  "order": "14.2",
   "title": "Comparing Peak Apparent Magnitudes",
   "slug": "distance-to-supernovae-1-3/",
   "previous": {
@@ -31,7 +31,8 @@
         [{ "accessor": "magnitude", "id": "163" }],
         [{ "accessor": "magnitude", "id": "164" }],
         [{ "accessor": "magnitude", "id": "165" }]
-      ]
+      ],
+      "qaReview": false
     }
   ],
   "questionsByPage": [

--- a/src/data/pages/distance-to-supernovae-1.json
+++ b/src/data/pages/distance-to-supernovae-1.json
@@ -1,7 +1,7 @@
 {
   "id": "12",
   "investigation": "exploding-stars",
-  "order": "16",
+  "order": "12",
   "title": "Determining the Peak Apparent Magnitude of Supernova #4",
   "slug": "distance-to-supernovae-1/",
   "previous": {

--- a/src/data/pages/distance-to-supernovae-2-1.json
+++ b/src/data/pages/distance-to-supernovae-2-1.json
@@ -1,7 +1,7 @@
 {
-  "id": "13b",
+  "id": "15b",
   "investigation": "exploding-stars",
-  "order": "19b",
+  "order": "15.2",
   "title": "How Galaxies are Arranged in Space",
   "slug": "distance-to-supernovae-2-1/",
   "previous": {

--- a/src/data/pages/distance-to-supernovae-2.json
+++ b/src/data/pages/distance-to-supernovae-2.json
@@ -1,7 +1,7 @@
 {
-  "id": "13a",
+  "id": "15a",
   "investigation": "exploding-stars",
-  "order": "19a",
+  "order": "15.1",
   "title": "Calculating the Distance to Supernovae",
   "slug": "distance-to-supernovae-2/",
   "previous": {

--- a/src/data/pages/distance-to-supernovae-3.json
+++ b/src/data/pages/distance-to-supernovae-3.json
@@ -1,7 +1,7 @@
 {
-  "id": "15",
+  "id": "16",
   "investigation": "exploding-stars",
-  "order": "21",
+  "order": "16",
   "title": "Galaxy Distances in the Local Universe",
   "slug": "distance-to-supernovae-3/",
   "previous": {
@@ -65,7 +65,8 @@
           { "accessor": "magnitude", "id": "165" },
           { "accessor": "megaLightYears", "id": "68" }
         ]
-      ]
+      ],
+      "qaReview": false
     }
   ],
   "questionsByPage": [

--- a/src/data/pages/introduction.json
+++ b/src/data/pages/introduction.json
@@ -1,5 +1,5 @@
 {
-  "id": "1",
+  "id": "00",
   "investigation": "exploding-stars",
   "order": "00",
   "title": "Introduction",

--- a/src/data/pages/observing-supernovae.json
+++ b/src/data/pages/observing-supernovae.json
@@ -1,7 +1,7 @@
 {
-  "id": "4",
+  "id": "03",
   "investigation": "exploding-stars",
-  "order": "04",
+  "order": "03",
   "title": "Observing Supernovae",
   "slug": "observing-supernovae/",
   "previous": {
@@ -38,7 +38,8 @@
         "showSelector": true,
         "showLightCurve": true,
         "toggleDataPointsVisibility": "82",
-        "autoplay": true
+        "autoplay": true,
+        "qaReview": false
       }
     }
   ],

--- a/src/data/pages/searching-for-supernovae-1-1.json
+++ b/src/data/pages/searching-for-supernovae-1-1.json
@@ -1,7 +1,7 @@
 {
-  "id": "11b",
+  "id": "07b",
   "investigation": "exploding-stars",
-  "order": "12b",
+  "order": "07.2",
   "title": "Classifying Supernova #1",
   "slug": "searching-for-supernovae-1-1/",
   "previous": {
@@ -19,7 +19,8 @@
       "source": "/data/galaxies/ZTF19aavjzrz_r_lightcurve.json",
       "options": {
         "showLightCurve": true,
-        "lightCurveTemplates": ["Ia"]
+        "lightCurveTemplates": ["Ia"],
+        "qaReview": false
       }
     }
   ],

--- a/src/data/pages/searching-for-supernovae-1.json
+++ b/src/data/pages/searching-for-supernovae-1.json
@@ -1,7 +1,7 @@
 {
-  "id": "11a",
+  "id": "07a",
   "investigation": "exploding-stars",
-  "order": "12a",
+  "order": "07.1",
   "title": "Searching For Supernovae",
   "slug": "searching-for-supernovae-1/",
   "previous": {
@@ -23,7 +23,8 @@
         "showLightCurve": false,
         "toggleDataPointsVisibility": "90",
         "autoplay": true,
-        "loop": true
+        "loop": true,
+        "qaReview": false
       }
     }
   ],

--- a/src/data/pages/searching-for-supernovae-2-1.json
+++ b/src/data/pages/searching-for-supernovae-2-1.json
@@ -1,7 +1,7 @@
 {
-  "id": "21a",
+  "id": "09b",
   "investigation": "exploding-stars",
-  "order": "13b",
+  "order": "09.2",
   "title": "Classifying Supernova #2",
   "slug": "searching-for-supernovae-2-1/",
   "previous": {
@@ -19,7 +19,8 @@
       "source": "/data/galaxies/ZTF20acxzkkf.json",
       "options": {
         "showLightCurve": true,
-        "lightCurveTemplates": ["Ia"]
+        "lightCurveTemplates": ["Ia"],
+        "qaReview": false
       }
     }
   ],

--- a/src/data/pages/searching-for-supernovae-2.json
+++ b/src/data/pages/searching-for-supernovae-2.json
@@ -1,7 +1,7 @@
 {
-  "id": "21",
+  "id": "08a",
   "investigation": "exploding-stars",
-  "order": "13a",
+  "order": "08.1",
   "title": "Searching For Supernova #2",
   "slug": "searching-for-supernovae-2/",
   "previous": {
@@ -21,7 +21,8 @@
         "showSelector": true,
         "toggleDataPointsVisibility": "59",
         "autoplay": true,
-        "loop": false
+        "loop": false,
+        "qaReview": false
       }
     }
   ],

--- a/src/data/pages/searching-for-supernovae-3-1.json
+++ b/src/data/pages/searching-for-supernovae-3-1.json
@@ -1,7 +1,7 @@
 {
-  "id": "22b",
+  "id": "10b",
   "investigation": "exploding-stars",
-  "order": "14b",
+  "order": "10.2",
   "title": "Classifying Supernova #3",
   "slug": "searching-for-supernovae-3-1/",
   "previous": {
@@ -19,7 +19,8 @@
       "source": "/data/galaxies/ZTF20acxtewc.json",
       "options": {
         "showLightCurve": true,
-        "lightCurveTemplates": ["Ia"]
+        "lightCurveTemplates": ["Ia"],
+        "qaReview": false
       }
     }
   ],

--- a/src/data/pages/searching-for-supernovae-3.json
+++ b/src/data/pages/searching-for-supernovae-3.json
@@ -1,7 +1,7 @@
 {
-  "id": "22a",
+  "id": "10a",
   "investigation": "exploding-stars",
-  "order": "14a",
+  "order": "10.1",
   "title": "Searching For Supernova #3",
   "slug": "searching-for-supernovae-3/",
   "previous": {
@@ -21,7 +21,8 @@
         "showSelector": true,
         "toggleDataPointsVisibility": "60",
         "autoplay": true,
-        "loop": false
+        "loop": false,
+        "qaReview": false
       }
     }
   ],

--- a/src/data/pages/searching-for-supernovae-4-1.json
+++ b/src/data/pages/searching-for-supernovae-4-1.json
@@ -1,7 +1,7 @@
 {
-  "id": "23b",
+  "id": "11b",
   "investigation": "exploding-stars",
-  "order": "15b",
+  "order": "11.2",
   "title": "Using Type Ia Supernovae to Measure Distances",
   "slug": "searching-for-supernovae-4-1/",
   "previous": {

--- a/src/data/pages/searching-for-supernovae-4-2.json
+++ b/src/data/pages/searching-for-supernovae-4-2.json
@@ -1,7 +1,7 @@
 {
-  "id": "23c",
+  "id": "11c",
   "investigation": "exploding-stars",
-  "order": "15c",
+  "order": "11.3",
   "title": "Using Type Ia Supernovae to Measure Distances",
   "slug": "searching-for-supernovae-4-2/",
   "previous": {
@@ -20,7 +20,8 @@
       "options": {
         "showLightCurve": true,
         "lightCurveTemplates": ["Ia"],
-        "preSelectedLightCurveTemplate": "611"
+        "preSelectedLightCurveTemplate": "611",
+        "qaReview": false
       }
     }
   ],
@@ -34,7 +35,8 @@
           "questionType": "accordion",
           "label": "<p>Now practice fitting the Type Ia supernova template to this sample data:</p><ol><li>Click the Ia template tab at the top left of the light curve graph.</li><li>Practice dragging the template as far as you can in every direction: up, down, right, left.</li><li>Practice making the template as big and small as you can.</li><li>Change the template size and position to intersect as many points or error bars as possible. Since you are using real data, it is highly unlikely that you will get a perfect fit for all of your points. It is more important to fit most of the curve instead of just trying to fit the peak.</li><li>Click Save when you are satisfied with the fit of your template.</li><li>Place your cursor on the light curve, and a horizontal line will appear on the graph.</li><li>Move the line until it is aligned with the peak apparent magnitude (m) of the template (this may not be the highest data point!).  Click when you are satisfied with the position of the line, then SAVE when the apparent magnitude is reported.</li></ol>",
           "answerPre": "<span>Selected Supernova: </span>",
-          "answerAccessor": "light-curve-template"
+          "answerAccessor": "light-curve-template",
+          "qaReview": false
         }
       ]
     }

--- a/src/data/pages/searching-for-supernovae-4.json
+++ b/src/data/pages/searching-for-supernovae-4.json
@@ -1,7 +1,7 @@
 {
-  "id": "23a",
+  "id": "11a",
   "investigation": "exploding-stars",
-  "order": "15a",
+  "order": "11.1",
   "title": "Type Ia Supernovae as Standard Candles",
   "slug": "searching-for-supernovae-4/",
   "previous": {

--- a/src/data/pages/summary.json
+++ b/src/data/pages/summary.json
@@ -1,7 +1,7 @@
 {
   "id": "18",
   "investigation": "exploding-stars",
-  "order": "23",
+  "order": "18",
   "title": "Putting it all Together",
   "slug": "summary/",
   "previous": { "title": "Reflect and Discuss", "link": "/discuss-report/" },

--- a/src/fragments/question.js
+++ b/src/fragments/question.js
@@ -19,6 +19,7 @@ export const questionFragment = graphql`
         label
         value
       }
+      qaReview
     }
   }
 `;


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/<ID>

## What this change does ##

This change applies QA Review updates per Ardis direction found in at [this link](https://docs.google.com/document/d/1tx_aZmR4K8L-qJuSFchoU-KVqtQag6Q3wmVdOwVftnQ/edit#bookmark=id.9qjll6rb9upr).

## Notes for reviewers ##

- Add `qaReview` to question json in fragments to show/hide questions
  in QA Review page
- Hide specific widgets in QA Review page only on Exploding Stars
- Remove unsused variables throughout application

Include an indication of how detailed a review you want on a 1-10 scale. - 5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"

## Testing ##

n/a

## Checklist ##

If any of the following are true, please check them off
- [x] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Links

[webpage-url]/exploding-stars/qa-review/
