### PR TITLE
[EPO-4916] Add "Redness" trendline to Flux vs. Dist plot

### DIFF
--- a/src/components/charts/galacticProperties/Trendline.jsx
+++ b/src/components/charts/galacticProperties/Trendline.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { getElDims } from '../../../lib/utilities.js';
+
+class Trendline extends React.Component {
+  constructor(props) {
+    super(props);
+    this.label = React.createRef();
+    this.offset = 5;
+  }
+
+  getMidPoint(a, b) {
+    if (!a || !b) return null;
+    return a.map((pos, i) => {
+      return (pos + b[i]) / 2;
+    });
+  }
+
+  getLineTransform(start, terminus) {
+    const { pointUp } = this.props;
+
+    if (pointUp) {
+      return `rotate(180, ${this.getMidPoint(start, terminus)})`;
+    }
+
+    return `rotate(0)`;
+  }
+
+  getLabelPos(terminus, rectDims) {
+    const [x, y] = terminus;
+    const { width, height } = rectDims;
+    return [x - width / 2, height / 2 + y / 2];
+  }
+
+  getStart() {
+    const { xScale, domain, padding } = this.props;
+    const offset = padding / 2;
+    return [xScale(domain[0][1]) - offset, offset];
+  }
+
+  getTerminus() {
+    const { xScale, yScale, domain, padding } = this.props;
+    const offset = padding / 2;
+    return [xScale(domain[0][1]) - offset, yScale(domain[0][0]) - offset];
+  }
+
+  render() {
+    const { text } = this.props;
+    const start = this.getStart();
+    const terminus = this.getTerminus();
+    const rectDims = getElDims(this.label.current);
+    const textPos = this.getLabelPos(terminus, rectDims);
+
+    return (
+      <svg>
+        <defs>
+          <marker
+            id="triangle"
+            viewBox="0 0 10 10"
+            refX="1"
+            refY="5"
+            markerUnits="strokeWidth"
+            markerWidth="15"
+            markerHeight="15"
+            orient="auto"
+          >
+            <path d="M 0 0 L 10 5 L 0 10 z" />
+          </marker>
+        </defs>
+        <g>
+          <line
+            x1={start[0]}
+            y1={start[1]}
+            x2={terminus[0]}
+            y2={terminus[1]}
+            strokeWidth={2}
+            stroke="#000000"
+            strokeDasharray="10"
+            markerEnd="url(#triangle)"
+            transform={this.getLineTransform(start, terminus)}
+          />
+          <rect
+            width={rectDims.width + 2 * this.offset}
+            height={rectDims.height + 2 * this.offset}
+            x={textPos[0] - this.offset}
+            y={textPos[1] - rectDims.height}
+            fill="#ffffff"
+            strokeWidth="2"
+            stroke="#000000"
+          ></rect>
+
+          <text ref={this.label} x={textPos[0]} y={textPos[1]}>
+            {text}
+          </text>
+        </g>
+      </svg>
+    );
+  }
+}
+
+Trendline.propTypes = {
+  text: PropTypes.string,
+  xScale: PropTypes.func,
+  yScale: PropTypes.func,
+  padding: PropTypes.number,
+  domain: PropTypes.array,
+  pointUp: PropTypes.bool,
+};
+
+export default Trendline;

--- a/src/components/charts/galacticProperties/index.jsx
+++ b/src/components/charts/galacticProperties/index.jsx
@@ -18,6 +18,7 @@ import XAxis from './XAxis.jsx';
 import YAxis from './YAxis.jsx';
 import LegendMultiple from './LegendMultiple.jsx';
 import Tooltip from '../shared/Tooltip.jsx';
+import Trendline from './Trendline.jsx';
 import styles from './galactic-properties.module.scss';
 
 class GalacticProperties extends React.Component {
@@ -93,6 +94,7 @@ class GalacticProperties extends React.Component {
   getXScale() {
     const { width, padding, xDomain, options } = this.props;
     const { domain } = options || {};
+
     return d3ScaleLinear()
       .domain(domain ? domain[0] : xDomain)
       .range([padding, width]);
@@ -287,9 +289,11 @@ class GalacticProperties extends React.Component {
       tooltipUnits,
       tooltipLabels,
       options,
+      xDomain,
+      yDomain,
     } = this.props;
 
-    const { svgShapes, color } = options || {};
+    const { svgShapes, color, domain } = options || {};
 
     const {
       xScale,
@@ -303,6 +307,7 @@ class GalacticProperties extends React.Component {
     } = this.state;
 
     const { multiple } = options || {};
+    const isBrightnessPlot = yValueAccessor === 'brightness';
     const svgClasses = classnames('svg-chart', styles.galacticProperties, {
       loading,
       loaded: !loading,
@@ -417,6 +422,22 @@ class GalacticProperties extends React.Component {
                 />
               )}
             </g>
+            {(yValueAccessor === 'color' || isBrightnessPlot) && (
+              <Trendline
+                text={isBrightnessPlot ? 'Brighter' : 'Redder'}
+                domain={domain || [xDomain, yDomain]}
+                pointUp={isBrightnessPlot}
+                {...{
+                  xScale,
+                  yScale,
+                  height,
+                  width,
+                  padding,
+                  offsetTop,
+                  offsetRight,
+                }}
+              />
+            )}
           </svg>
         </div>
       </>


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-4916

## What this change does ##

This change adds the Redness trendline to the Flux vs. Distance plot. This trendline was pulled from the Hubble Plot and stripped to create this redness trendline.

## Notes for reviewers ##

Adds two additional trendline parameters to the GalacticProperties widget that controls the visibility and text of the trendline.

Include an indication of how detailed a review you want on a 1-10 scale.

**5** "Please make sure there are no obvious errors and that you believe it does what it says it does"

## Testing ##

How did you test this change?  Can the reviewers test this change for themselves?

If you wrote new tests in the change it's fine to just put "New tests in PR". If you haven't added any tests but you think your change is covered by existing tests you can say "Existing tests". And if you're not sure how to test it, say that.


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user-visible.
- [ ] This change impacts several investigations (e.g. the change affects reused styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
![image](https://user-images.githubusercontent.com/8799443/126715803-92673734-5fc2-4450-afd1-1b1c648fcbf3.png)

### After:
![image](https://user-images.githubusercontent.com/8799443/126715732-4005f46e-7beb-45f7-aad8-0d9f0b4cddf5.png)

