### PR TITLE
[C] Reorder Orbital Characteristics questions

### DIFF
--- a/src/data/pages/characterizing-comet.json
+++ b/src/data/pages/characterizing-comet.json
@@ -113,6 +113,37 @@
     {
       "question": [
         {
+          "id": "18",
+          "questionType": "select",
+          "title": "Question #1",
+          "label": "Size of the orbit: ",
+          "options": [
+            {
+              "label": "All of the orbits are within the inner Solar System (between 0.5 - 4 au).",
+              "value": "Within inner Solar System (between 0.5 - 4 au)"
+            },
+            {
+              "label": "All of the orbits are within the inner Solar System (between 1.5 - 5.2 au).",
+              "value": "Within inner Solar System (between 1.5 - 5.2 au)"
+            },
+            {
+              "label": "All of the orbits are located in the outer Solar System beyond the orbit of Jupiter (greater than 5.2 au).",
+              "value": "In the outer Solar System"
+            },
+            {
+              "label": "The orbit sizes span both the inner and outer Solar System.",
+              "value": "Span inner and outer Solar System"
+            }
+          ],
+          "placeholder": "Select best description of comets",
+          "answerPre": "<p>Selected: </p>",
+          "answerAccessor": "data"
+        }
+      ]
+    },
+    {
+      "question": [
+        {
           "id": "16",
           "questionType": "select",
           "title": "Question #1",
@@ -179,37 +210,6 @@
             {
               "label": "A significant number of objects (more than 10%) orbit the Sun in the opposite direction of Earth’s orbit, i >90 ",
               "value": "More than 10% are opposite direction as Earth’s"
-            }
-          ],
-          "placeholder": "Select best description of comets",
-          "answerPre": "<p>Selected: </p>",
-          "answerAccessor": "data"
-        }
-      ]
-    },
-    {
-      "question": [
-        {
-          "id": "18",
-          "questionType": "select",
-          "title": "Question #1",
-          "label": "Size of the orbit: ",
-          "options": [
-            {
-              "label": "All of the orbits are within the inner Solar System (between 0.5 - 4 au).",
-              "value": "Within inner Solar System (between 0.5 - 4 au)"
-            },
-            {
-              "label": "All of the orbits are within the inner Solar System (between 1.5 - 5.2 au).",
-              "value": "Within inner Solar System (between 1.5 - 5.2 au)"
-            },
-            {
-              "label": "All of the orbits are located in the outer Solar System beyond the orbit of Jupiter (greater than 5.2 au).",
-              "value": "In the outer Solar System"
-            },
-            {
-              "label": "The orbit sizes span both the inner and outer Solar System.",
-              "value": "Span inner and outer Solar System"
             }
           ],
           "placeholder": "Select best description of comets",

--- a/src/data/pages/characterizing-mba.json
+++ b/src/data/pages/characterizing-mba.json
@@ -113,6 +113,37 @@
     {
       "question": [
         {
+          "id": "10",
+          "questionType": "select",
+          "title": "Question #1",
+          "label": "Size of the orbit: ",
+          "options": [
+            {
+              "label": "All of the orbits are within the inner Solar System (between 0.5 - 4 au).",
+              "value": "Within inner Solar System (between 0.5 - 4 au)"
+            },
+            {
+              "label": "All of the orbits are within the inner Solar System (between 1.5 - 5.2 au).",
+              "value": "Within inner Solar System (between 1.5 - 5.2 au)"
+            },
+            {
+              "label": "All of the orbits are located in the outer Solar System beyond the orbit of Jupiter (greater than 5.2 au).",
+              "value": "In the outer Solar System"
+            },
+            {
+              "label": "The orbit sizes span both the inner and outer Solar System.",
+              "value": "Span inner and outer Solar System"
+            }
+          ],
+          "placeholder": "Select best description of MBAs",
+          "answerPre": "<p>Selected: </p>",
+          "answerAccessor": "data"
+        }
+      ]
+    },
+    {
+      "question": [
+        {
           "id": "8",
           "questionType": "select",
           "title": "Question #1",
@@ -179,37 +210,6 @@
             {
               "label": "A significant number of objects (more than 10%) orbit the Sun in the opposite direction of Earth’s orbit, i >90 ",
               "value": "Opposite direction as Earth’s"
-            }
-          ],
-          "placeholder": "Select best description of MBAs",
-          "answerPre": "<p>Selected: </p>",
-          "answerAccessor": "data"
-        }
-      ]
-    },
-    {
-      "question": [
-        {
-          "id": "10",
-          "questionType": "select",
-          "title": "Question #1",
-          "label": "Size of the orbit: ",
-          "options": [
-            {
-              "label": "All of the orbits are within the inner Solar System (between 0.5 - 4 au).",
-              "value": "Within inner Solar System (between 0.5 - 4 au)"
-            },
-            {
-              "label": "All of the orbits are within the inner Solar System (between 1.5 - 5.2 au).",
-              "value": "Within inner Solar System (between 1.5 - 5.2 au)"
-            },
-            {
-              "label": "All of the orbits are located in the outer Solar System beyond the orbit of Jupiter (greater than 5.2 au).",
-              "value": "In the outer Solar System"
-            },
-            {
-              "label": "The orbit sizes span both the inner and outer Solar System.",
-              "value": "Span inner and outer Solar System"
             }
           ],
           "placeholder": "Select best description of MBAs",

--- a/src/data/pages/characterizing-neo.json
+++ b/src/data/pages/characterizing-neo.json
@@ -113,6 +113,37 @@
     {
       "question": [
         {
+          "id": "6",
+          "questionType": "select",
+          "title": "Question #1",
+          "label": "Size of the orbit: ",
+          "options": [
+            {
+              "label": "All of the orbits are within the inner Solar System (between 0.5 - 4 au).",
+              "value": "Within inner Solar System (between 0.5 - 4 au)"
+            },
+            {
+              "label": "All of the orbits are within the inner Solar System (between 1.5 - 5.2 au).",
+              "value": "Within inner Solar System (between 1.5 - 5.2 au)"
+            },
+            {
+              "label": "All of the orbits are located in the outer Solar System beyond the orbit of Jupiter (greater than 5.2 au).",
+              "value": "In the outer Solar System"
+            },
+            {
+              "label": "The orbit sizes span both the inner and outer Solar System.",
+              "value": "Span inner and outer Solar System"
+            }
+          ],
+          "placeholder": "Select best description of NEOs",
+          "answerPre": "<p>Selected: </p>",
+          "answerAccessor": "data"
+        }
+      ]
+    },
+    {
+      "question": [
+        {
           "id": "4",
           "questionType": "select",
           "title": "Question #1",
@@ -179,37 +210,6 @@
             {
               "label": "More than 10% of the objects orbit the Sun in the opposite direction of Earth’s orbit, (i >90°).",
               "value": "Opposite direction as Earth’s"
-            }
-          ],
-          "placeholder": "Select best description of NEOs",
-          "answerPre": "<p>Selected: </p>",
-          "answerAccessor": "data"
-        }
-      ]
-    },
-    {
-      "question": [
-        {
-          "id": "6",
-          "questionType": "select",
-          "title": "Question #1",
-          "label": "Size of the orbit: ",
-          "options": [
-            {
-              "label": "All of the orbits are within the inner Solar System (between 0.5 - 4 au).",
-              "value": "Within inner Solar System (between 0.5 - 4 au)"
-            },
-            {
-              "label": "All of the orbits are within the inner Solar System (between 1.5 - 5.2 au).",
-              "value": "Within inner Solar System (between 1.5 - 5.2 au)"
-            },
-            {
-              "label": "All of the orbits are located in the outer Solar System beyond the orbit of Jupiter (greater than 5.2 au).",
-              "value": "In the outer Solar System"
-            },
-            {
-              "label": "The orbit sizes span both the inner and outer Solar System.",
-              "value": "Span inner and outer Solar System"
             }
           ],
           "placeholder": "Select best description of NEOs",

--- a/src/data/pages/characterizing-tno.json
+++ b/src/data/pages/characterizing-tno.json
@@ -113,6 +113,37 @@
     {
       "question": [
         {
+          "id": "14",
+          "questionType": "select",
+          "title": "Question #1",
+          "label": "Size of the orbit: ",
+          "options": [
+            {
+              "label": "All of the orbits are within the inner Solar System (between 0.5 - 4 au).",
+              "value": "Within inner Solar System (between 0.5 - 4 au)"
+            },
+            {
+              "label": "All of the orbits are within the inner Solar System (between 1.5 - 5.2 au).",
+              "value": "Within inner Solar System (between 1.5 - 5.2 au)"
+            },
+            {
+              "label": "All of the orbits are located in the outer Solar System beyond the orbit of Jupiter (greater than 5.2 au).",
+              "value": "In the outer Solar System"
+            },
+            {
+              "label": "The orbit sizes span both the inner and outer Solar System.",
+              "value": "Span inner and outer Solar System"
+            }
+          ],
+          "placeholder": "Select best description of TNOs",
+          "answerPre": "<p>Selected: </p>",
+          "answerAccessor": "data"
+        }
+      ]
+    },
+    {
+      "question": [
+        {
           "id": "12",
           "questionType": "select",
           "title": "Question #1",
@@ -179,37 +210,6 @@
             {
               "label": "A significant number of objects (more than 10%) orbit the Sun in the opposite direction of Earth’s orbit, i >90 ",
               "value": "Opposite direction as Earth’s"
-            }
-          ],
-          "placeholder": "Select best description of TNOs",
-          "answerPre": "<p>Selected: </p>",
-          "answerAccessor": "data"
-        }
-      ]
-    },
-    {
-      "question": [
-        {
-          "id": "14",
-          "questionType": "select",
-          "title": "Question #1",
-          "label": "Size of the orbit: ",
-          "options": [
-            {
-              "label": "All of the orbits are within the inner Solar System (between 0.5 - 4 au).",
-              "value": "Within inner Solar System (between 0.5 - 4 au)"
-            },
-            {
-              "label": "All of the orbits are within the inner Solar System (between 1.5 - 5.2 au).",
-              "value": "Within inner Solar System (between 1.5 - 5.2 au)"
-            },
-            {
-              "label": "All of the orbits are located in the outer Solar System beyond the orbit of Jupiter (greater than 5.2 au).",
-              "value": "In the outer Solar System"
-            },
-            {
-              "label": "The orbit sizes span both the inner and outer Solar System.",
-              "value": "Span inner and outer Solar System"
             }
           ],
           "placeholder": "Select best description of TNOs",


### PR DESCRIPTION
For JIRA: "EPO-5424 #IN-REVIEW #comment Reorder orbital characteristics questions"

JIRA: https://jira.lsstcorp.org/browse/EPO-5424

## What this change does ##

Re-orders the orbital characteristics pages of Surveying the Solar System to go in order of Semi-major axis, eccentricity, and inclination.

## Notes for reviewers ##

Observe that the semi-major axis questions ("size of the orbit") questions for each of the 4 orbital characteristics pages (NEO, MBA, TNO, Comets) is re-ordered to be ahead of the eccentricity and inclination questions.

4

## Testing ##

Tested by using the Surveying the Solar System investigation up through the Orbital Characteristics pages and verifying the order of questions.

## Checklist ##

If any of the following are true, please check them off
- [x] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [ ] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does