### PR TITLE
[C] EPO-5643 - Refactor QAs into QuestionBlock

### DIFF
--- a/src/components/page/SingleCol.jsx
+++ b/src/components/page/SingleCol.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import QAs from '../qas';
 import BlocksLayout from './blocks/BlocksLayout.jsx';
 
-import { singleColGrid, gridTitle, gridQas } from './page.module.scss';
+import { singleColGrid, gridTitle } from './page.module.scss';
 
 class Page extends React.PureComponent {
   render() {
@@ -52,6 +51,10 @@ class Page extends React.PureComponent {
         type: 'checkpoint',
         blocks: checkpoints,
       },
+      {
+        type: 'question',
+        blocks: questions,
+      },
     ];
 
     return (
@@ -73,11 +76,6 @@ class Page extends React.PureComponent {
           }}
           {...{ blocksGroups, defaultLayout, blockShared }}
         />
-        {questions && (
-          <div className={gridQas}>
-            <QAs {...blockShared} />
-          </div>
-        )}
         {/* Bottom */}
         <BlocksLayout
           layout={{

--- a/src/components/page/TwoCol.jsx
+++ b/src/components/page/TwoCol.jsx
@@ -2,13 +2,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import find from 'lodash/find';
-import QAs from '../qas';
 import BlocksLayout from './blocks/BlocksLayout.jsx';
 import Placeholder from '../placeholder';
 import {
   leftColGrid,
   gridTitle,
-  gridQas,
   rightColGrid,
   gridPlaceholder,
 } from './page.module.scss';
@@ -68,6 +66,10 @@ class TwoCol extends React.PureComponent {
         type: 'checkpoint',
         blocks: checkpoints,
       },
+      {
+        type: 'question',
+        blocks: questions,
+      },
     ];
 
     return (
@@ -93,11 +95,6 @@ class TwoCol extends React.PureComponent {
               }}
               {...{ blocksGroups, blockShared }}
             />
-            {questions && (
-              <div className={gridQas}>
-                <QAs {...blockShared} />
-              </div>
-            )}
             {/* Bottom Left */}
             <BlocksLayout
               layout={{

--- a/src/components/page/blocks/ContentBlock.jsx
+++ b/src/components/page/blocks/ContentBlock.jsx
@@ -10,7 +10,7 @@ import {
   gridCopyBottom,
 } from '../page.module.scss';
 
-class Content extends React.PureComponent {
+class ContentBlock extends React.PureComponent {
   constructor(props) {
     super(props);
 
@@ -34,9 +34,9 @@ class Content extends React.PureComponent {
   }
 }
 
-Content.propTypes = {
+ContentBlock.propTypes = {
   block: PropTypes.object,
   row: PropTypes.string,
 };
 
-export default Content;
+export default ContentBlock;

--- a/src/components/page/blocks/QuestionBlock.jsx
+++ b/src/components/page/blocks/QuestionBlock.jsx
@@ -1,0 +1,87 @@
+/* eslint-disable react/no-danger */
+import React from 'react';
+import PropTypes from 'prop-types';
+import QA from '../../qas/QA';
+import QACompound from '../../qas/questions/qaCompound';
+import { qa } from '../../qas/styles.module.scss';
+
+import { gridQasTop, gridQasMiddle, gridQasBottom } from '../page.module.scss';
+
+class QuestionBlock extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.gridClasses = {
+      top: gridQasTop,
+      middle: gridQasMiddle,
+      bottom: gridQasBottom,
+    };
+  }
+
+  render() {
+    const { blockShared, block } = this.props;
+    const { questions } = block;
+
+    const {
+      activeQuestionId,
+      advanceActiveQuestion,
+      answers,
+      qaReviewPage,
+      setActiveQuestion,
+      updateAnswer,
+    } = blockShared;
+
+    return (
+      <div className="qas">
+        {questions.map(question => {
+          const { question: q, number } = question;
+          const primeQ = q[0];
+          const { id, questionType, qaReview, showUserAnswer } = primeQ;
+          const key = `qa-${id}`;
+
+          if (qaReviewPage && !qaReview) return false;
+
+          if (q.length > 1) {
+            return (
+              <div className={qa} key={key}>
+                <QACompound
+                  activeId={activeQuestionId}
+                  questionNumber={+number}
+                  questions={q}
+                  answers={answers}
+                  handleAnswerSelect={updateAnswer}
+                />
+              </div>
+            );
+          }
+
+          const answer = answers[id];
+          const prepopulateAnswer = answers[showUserAnswer];
+
+          return (
+            <QA
+              key={key}
+              questionType={questionType}
+              questionNumber={+number}
+              question={primeQ}
+              answer={answer}
+              prepopulateAnswer={prepopulateAnswer}
+              activeId={activeQuestionId}
+              answerHandler={updateAnswer}
+              cancelHandler={updateAnswer}
+              saveHandler={advanceActiveQuestion}
+              editHandler={setActiveQuestion}
+            />
+          );
+        })}
+      </div>
+    );
+  }
+}
+
+QuestionBlock.propTypes = {
+  blockShared: PropTypes.object,
+  block: PropTypes.object,
+};
+
+export default QuestionBlock;

--- a/src/components/page/blocks/index.jsx
+++ b/src/components/page/blocks/index.jsx
@@ -6,6 +6,7 @@ import VideoBlock from './VideoBlock';
 import TableBlock from './TableBlock';
 import ContentBlock from './ContentBlock';
 import CheckpointBlock from './CheckpointBlock';
+import QuestionBlock from './QuestionBlock';
 
 class Blocks extends React.PureComponent {
   constructor(props) {
@@ -18,6 +19,7 @@ class Blocks extends React.PureComponent {
       table: TableBlock,
       content: ContentBlock,
       checkpoint: CheckpointBlock,
+      question: QuestionBlock,
     };
   }
 

--- a/src/containers/PageContainer.jsx
+++ b/src/containers/PageContainer.jsx
@@ -67,6 +67,9 @@ class PageContainer extends React.PureComponent {
     return contents;
   }
 
+  getQuestions = questions =>
+    questions ? [{ questions, layout: { row: 'middle', col: 'left' } }] : null;
+
   getQuestionsWithNumbers = (questionNumbers, questions) => {
     if (!questions || !questionNumbers) return [];
 
@@ -123,6 +126,7 @@ class PageContainer extends React.PureComponent {
       <div className="container-page">
         <Tag
           contents={this.getContents(content, contents)}
+          questions={this.getQuestions(questions)}
           {...{
             id,
             layout,
@@ -136,7 +140,6 @@ class PageContainer extends React.PureComponent {
             videos,
             answers,
             shared,
-            questions,
           }}
         />
         <PageNav


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/<ID>

## What this change does ##

Previously the questions in investigations were rendered outside of the layout flow that the other block components exist in. The `QAs` component has been normalized into a `QuestionBlock` component that accepts a layout position the same as other block components. A default layout for QuestionBlock has also been created at the `PageContainer` level to closely approximate it's previous position after the `middle left` content. 

After looking through several investigations the layouts appear to match their previous position and no major layout change has occurred.

## Notes for reviewers ##

Observe that the questions appear in their expected location and function identically to how they did prior to this change. No work was done on the blocks themselves apart from creating a `QuestionBlock` component and adding the questions to the `blockGroup` object in the column layout components.

Include an indication of how detailed a review you want on a 1-10 scale.
- 5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"

## Testing ##

Tested by comparing the investigation post-refactor to it's original state and verifying that questions appear in the expected location.

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [ ] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does
