### PR TITLE
[C] Fix Oort Cloud link

### DIFF
--- a/src/data/pages/history-solar-system.json
+++ b/src/data/pages/history-solar-system.json
@@ -20,7 +20,7 @@
     },
     {
       "layout": { "col": "left", "row": "middle" },
-      "content": "<p>The <a href='http://rubineducation.org/glossary#oort_cloud' target='_blank'>Oort Cloud</a> is a spherical region of icy objects that exists at the outermost edges of the Solar System (extending from a distance of 1000 - 100,000 au), thought to have formed after the collapse of the solar nebula. One idea suggests that gravitational interactions between large planets and small Solar System objects in the early years of the Solar System slung small objects outwards to form the Oort Cloud. Another idea suggests the Sun’s gravity could have plucked some objects from other nearby solar systems.</p>"
+      "content": "<p>The <a href='http://rubineducation.org/glossary/oort-cloud' target='_blank'>Oort Cloud</a> is a spherical region of icy objects that exists at the outermost edges of the Solar System (extending from a distance of 1000 - 100,000 au), thought to have formed after the collapse of the solar nebula. One idea suggests that gravitational interactions between large planets and small Solar System objects in the early years of the Solar System slung small objects outwards to form the Oort Cloud. Another idea suggests the Sun’s gravity could have plucked some objects from other nearby solar systems.</p>"
     }
   ],
   "images": [


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-5704

## What this change does ##

Fix the Oort Cloud glossary link to navigate to the definition page instead of an anchor link in the main glossary

## Notes for reviewers ##

Include an indication of how detailed a review you want on a 1-10 scale.
- 1 = "I barely need review on this"

## Testing ##

Verify that the link goes to the Oort Cloud definition page

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
