### PR TITLE
[C] Remove answers popup

### DIFF
--- a/src/components/pageNav/index.jsx
+++ b/src/components/pageNav/index.jsx
@@ -16,7 +16,6 @@ class PageNav extends React.PureComponent {
 
     this.state = {
       showAllRequiredNotification: false,
-      showCompletedNotification: false,
     };
   }
 
@@ -25,7 +24,6 @@ class PageNav extends React.PureComponent {
     const { allQuestionsAnswered: prevAllQuestionsAnswered } = prevProps;
 
     if (allQuestionsAnswered && !prevAllQuestionsAnswered) {
-      this.handleShowCompletedNotification();
       this.handleHideAllRequiredNotification();
     }
   }
@@ -42,14 +40,6 @@ class PageNav extends React.PureComponent {
     this.setState(prevState => ({
       ...prevState,
       showAllRequiredNotification: false,
-    }));
-  };
-
-  handleShowCompletedNotification = () => {
-    const { allQuestionsAnswered } = this.props;
-    this.setState(prevState => ({
-      ...prevState,
-      showCompletedNotification: true && allQuestionsAnswered,
     }));
   };
 
@@ -131,10 +121,7 @@ class PageNav extends React.PureComponent {
 
   render() {
     const { previous, next, baseUrl, allQuestionsAnswered } = this.props;
-    const {
-      showAllRequiredNotification,
-      showCompletedNotification,
-    } = this.state;
+    const { showAllRequiredNotification } = this.state;
 
     return (
       <>
@@ -145,27 +132,6 @@ class PageNav extends React.PureComponent {
           icon="StopIcon"
         >
           <p>Please answer all questions before continuing to the next page.</p>
-        </Notification>
-        <Notification
-          classes={styles.answersCompleted}
-          show={showCompletedNotification}
-          delay={15000}
-          showFor={8000}
-          handleClose={() => {
-            this.setState(prevState => ({
-              ...prevState,
-              showCompletedNotification: false,
-            }));
-          }}
-          icon="CheckmarkIcon"
-        >
-          <p>
-            You answered all of the questions on this page.{' '}
-            <Link to={this.getNavLink('next', next, baseUrl)}>
-              Go to the next page
-            </Link>{' '}
-            when you&apos;re ready.
-          </p>
         </Notification>
         <div className={styles.pageNavigation}>
           <nav role="navigation" className={styles.navSecondary}>


### PR DESCRIPTION
For JIRA: "EPO-5820 #IN-REVIEW #comment Remove answers popup"

JIRA: https://jira.lsstcorp.org/browse/EPO-5820

## What this change does ##

The pop-up notification that displayed on a 15s delay after answering all questions on the page has been removed.

## Notes for reviewers ##

The pop-up and the enabling code that displays that "You have answered all the questions on the page" notification has been removed. Some of the code is still left in place, particularly to hide the "Please answer all questions before continuing to the next page." pop-up when all questions have been answered.

Include an indication of how detailed a review you want on a 1-10 scale.
- 3

## Testing ##

Clear local storage of any previously answered questions. Complete a set of questions in a page and wait 15s, no pop-up should display. On another page, try to click forward before completing the questions and observe the "Please answer all questions before continuing to the next page." pop-up. Complete the questions and observe that the pop-up disappears.

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
