### PR TITLE
[F] Redesign investigations progress bar

### DIFF
--- a/src/assets/stylesheets/_variables.scss
+++ b/src/assets/stylesheets/_variables.scss
@@ -13,6 +13,7 @@ $brightGreen: #01bbbc;
 $mediumGreen: #058b8c;
 $ral5018HR: #087f80;
 $boldRed: #df0039;
+$successGreen: #019105;
 
 // Accent Warm Colors
 $awRed: #ed4c4c;
@@ -155,7 +156,9 @@ $break30: 320px;
 // --------------------------------------------------------
 $containerMaxWidth: $break100;
 
-$siteHeaderHeight: 64px;
+$siteProgressHeight: 26px;
+$siteToolbarHeight: 64px;
+$siteHeaderHeight: $siteProgressHeight + $siteToolbarHeight;
 $pageNavHeight: 64px;
 
 $minPadding: 20px;
@@ -165,7 +168,7 @@ $verticalSpace: $baseLineHeight * 1em;
 $headingWithSpaceHeight: 90px;
 $tallestSquareWidget: calc(
   100vh - #{$pageNavHeight} - #{$siteHeaderHeight} - #{$headingWithSpaceHeight} -
-  #{$minPadding}
+    #{$minPadding}
 );
 
 // $durationFast: 0.1s;

--- a/src/assets/stylesheets/components/site/progress/_header-progress.scss
+++ b/src/assets/stylesheets/components/site/progress/_header-progress.scss
@@ -1,0 +1,18 @@
+.header-progress-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: $siteProgressHeight;
+  padding: 0 $minPadding;
+  background-color: rgb(245, 245, 245);
+}
+
+.header-progress-checkpoints {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+}

--- a/src/assets/stylesheets/components/site/progress/_index.scss
+++ b/src/assets/stylesheets/components/site/progress/_index.scss
@@ -1,2 +1,3 @@
 @import 'progress-donut';
 @import 'progress-linear';
+@import 'header-progress';

--- a/src/assets/stylesheets/components/site/progress/_progress-linear.scss
+++ b/src/assets/stylesheets/components/site/progress/_progress-linear.scss
@@ -1,11 +1,57 @@
 .progress-linear-container {
-  display: block;
+  position: relative;
+  display: flex;
+  align-items: center;
   width: 100%;
-  height: 5px;
-  background: $baseSecondary;
+  height: 2px;
+  background: $neutral30;
 
   .progress-linear {
-    height: 100%;
-    background: $awOrange;
+    height: 8px;
+    background: $successGreen;
+    border-radius: 4px;
+  }
+}
+
+.progress-linear-marker {
+  $progressLinearMarkerWidth: 22px;
+
+  position: absolute;
+  left: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: $progressLinearMarkerWidth;
+  height: $progressLinearMarkerWidth;
+  font-size: 10px;
+  color: $black;
+  background-color: $white;
+  border: 3px solid $neutral30;
+  border-radius: $progressLinearMarkerWidth / 2;
+  transform: translateX(-($progressLinearMarkerWidth / 2));
+
+  &.hoverable {
+    cursor: pointer;
+    transition: transform 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+
+    &:hover {
+      transform: translateX(-($progressLinearMarkerWidth / 2)) scale(2);
+
+      .progress-linear-hover-text {
+        opacity: 1;
+      }
+    }
+
+    .progress-linear-hover-text {
+      font-size: 8px;
+      line-height: 1;
+      opacity: 0;
+      transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+    }
+  }
+
+  &.completed {
+    border-color: $successGreen;
   }
 }

--- a/src/components/site/header/HeaderProgress.jsx
+++ b/src/components/site/header/HeaderProgress.jsx
@@ -1,0 +1,49 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import CustomIcon from '../icons/CustomIcon';
+import LinearProgress from '../linearProgress';
+import LinearProgressMarker from '../linearProgress/LinearProgressMarker';
+
+class HeaderProgress extends React.PureComponent {
+  render = () => {
+    const { checkpoints, pageNumber, totalPages } = this.props;
+    return (
+      <div className="header-progress-wrapper">
+        <LinearProgress
+          id="current-page-of-total"
+          value={pageNumber ? Math.round((pageNumber / totalPages) * 100) : 0}
+        >
+          {checkpoints.length > 0 && (
+            <div className="header-progress-checkpoints">
+              {checkpoints.map(checkpoint => {
+                return (
+                  <LinearProgressMarker
+                    key={checkpoint}
+                    completed={pageNumber >= checkpoint}
+                    progress={Math.round((checkpoint / totalPages) * 100)}
+                  >
+                    <CustomIcon name="checkpoint" />
+                  </LinearProgressMarker>
+                );
+              })}
+              <LinearProgressMarker
+                completed={pageNumber >= totalPages}
+                progress={100}
+              >
+                <CustomIcon name="finish" />
+              </LinearProgressMarker>
+            </div>
+          )}
+        </LinearProgress>
+      </div>
+    );
+  };
+}
+
+HeaderProgress.propTypes = {
+  pageNumber: PropTypes.number,
+  totalPages: PropTypes.number,
+  checkpoints: PropTypes.array,
+};
+
+export default HeaderProgress;

--- a/src/components/site/header/HeaderProgress.jsx
+++ b/src/components/site/header/HeaderProgress.jsx
@@ -13,7 +13,7 @@ class HeaderProgress extends React.PureComponent {
           id="current-page-of-total"
           value={pageNumber ? Math.round((pageNumber / totalPages) * 100) : 0}
         >
-          {checkpoints.length > 0 && (
+          {checkpoints && (
             <div className="header-progress-checkpoints">
               {checkpoints.map(checkpoint => {
                 return (
@@ -26,14 +26,14 @@ class HeaderProgress extends React.PureComponent {
                   </LinearProgressMarker>
                 );
               })}
-              <LinearProgressMarker
-                completed={pageNumber >= totalPages}
-                progress={100}
-              >
-                <CustomIcon name="finish" />
-              </LinearProgressMarker>
             </div>
           )}
+          <LinearProgressMarker
+            completed={pageNumber >= totalPages}
+            progress={100}
+          >
+            <CustomIcon name="finish" />
+          </LinearProgressMarker>
         </LinearProgress>
       </div>
     );

--- a/src/components/site/header/header.module.scss
+++ b/src/components/site/header/header.module.scss
@@ -1,3 +1,5 @@
+$md-toolbar-tablet-height: $siteHeaderHeight;
+
 :global {
   @include react-md-toolbars;
 }
@@ -6,22 +8,12 @@
   display: block;
 }
 
-.progress-bar-wrapper {
-  :global {
-    .progress-linear-container {
-      position: absolute;
-      bottom: 0;
-      padding: 0;
-      margin: 0;
-    }
-  }
-}
-
 .inner-container {
   display: flex;
   align-items: center;
   justify-content: space-between;
   width: 100%;
+  height: $siteToolbarHeight;
   margin: 0 auto;
 }
 

--- a/src/components/site/header/index.jsx
+++ b/src/components/site/header/index.jsx
@@ -1,13 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Toolbar } from 'react-md';
-import LinearProgress from '../linearProgress';
 import Button from '../button/index';
 import ButtonIcon from '../button/ButtonIcon';
 import Close from '../icons/Close';
 import Menu from '../icons/Menu';
 
 import styles from './header.module.scss';
+import HeaderProgress from './HeaderProgress';
 
 class Header extends React.PureComponent {
   checkQAProgress(pageId) {
@@ -23,6 +23,7 @@ class Header extends React.PureComponent {
 
   render() {
     const {
+      checkpoints,
       investigationTitle,
       toggleToc,
       tocVisability,
@@ -40,12 +41,6 @@ class Header extends React.PureComponent {
         titleClassName="screen-reader-only"
         className={`${styles.headerPrimary} dont-print`}
       >
-        <div className={styles.progressBarWrapper}>
-          <LinearProgress
-            id="current-page-of-total"
-            value={pageNumber ? (pageNumber / totalPages) * 100 : 0}
-          />
-        </div>
         <div className={styles.innerContainer}>
           {toggleToc && (
             <Button
@@ -90,12 +85,14 @@ class Header extends React.PureComponent {
             )}
           </div>
         </div>
+        <HeaderProgress {...{ checkpoints, pageNumber, totalPages }} />
       </Toolbar>
     );
   }
 }
 
 Header.propTypes = {
+  checkpoints: PropTypes.array,
   investigationTitle: PropTypes.string,
   tocVisability: PropTypes.bool,
   toggleToc: PropTypes.func,

--- a/src/components/site/icons/Checkpoint.jsx
+++ b/src/components/site/icons/Checkpoint.jsx
@@ -1,0 +1,21 @@
+/* eslint-disable react/jsx-props-no-spreading */
+
+import React from 'react';
+import SVGIcon from 'react-md/lib/SVGIcons/SVGIcon';
+import './icon.module.scss';
+
+const Checkpoint = props => (
+  <SVGIcon {...props} role="presentation" viewBox="87 87 26 26">
+    <circle fill="#d9f7f6" cx="100" cy="100" r="13" />
+    <path
+      fill="#ed4c4c"
+      d="M 101.965 97.031 L 98.838 93.378 C 99.205 92.574 99.367 91.692 99.309 90.811 L 91.8 96.067 C 92.61 96.424 93.496 96.574 94.378 96.504 L 96.731 100.685 C 96.183 102.007 96.123 103.481 96.563 104.843 L 105.922 98.286 C 104.794 97.411 103.391 96.966 101.965 97.031 Z"
+    />
+    <polygon
+      fill="#8a8c8c"
+      points="100.576 102.03 103.994 106.905 106.011 106.961 101.898 101.1 100.576 102.03"
+    />
+  </SVGIcon>
+);
+
+export default Checkpoint;

--- a/src/components/site/icons/CustomIcon.jsx
+++ b/src/components/site/icons/CustomIcon.jsx
@@ -10,9 +10,11 @@ import check from './Check';
 import checkBox from './CheckBox';
 import checkBoxOutlineBlank from './CheckBoxOutlineBlank';
 import checkmark from './Checkmark';
+import checkpoint from './Checkpoint';
 import close from './Close';
 import dragHandle from './DragHandle';
 import fastForward from './FastForward';
+import finish from './Finish';
 import galaxy from './Galaxy';
 import indeterminateCheckBox from './IndeterminateCheckBox';
 import lightbulb from './Lightbulb';
@@ -40,9 +42,11 @@ const icons = {
   checkBox,
   checkBoxOutlineBlank,
   checkmark,
+  checkpoint,
   close,
   dragHandle,
   fastForward,
+  finish,
   galaxy,
   indeterminateCheckBox,
   lightbulb,

--- a/src/components/site/icons/Finish.jsx
+++ b/src/components/site/icons/Finish.jsx
@@ -1,0 +1,73 @@
+/* eslint-disable react/jsx-props-no-spreading */
+
+import React from 'react';
+import SVGIcon from 'react-md/lib/SVGIcons/SVGIcon';
+import './icon.module.scss';
+
+const Finish = props => (
+  <SVGIcon {...props} role="presentation" viewBox="87 87 26 26">
+    <circle fill="#fdda78" cx="100" cy="100" r="13" />
+    <rect
+      fill="#f5f5f5"
+      x="95.13"
+      y="94.34"
+      width="13.5"
+      height="10.13"
+      transform="matrix(-0.984808, -0.173648, 0.173648, -0.984808, 184.949997, 214.990005)"
+    />
+    <rect
+      fill="#1f2121"
+      x="105.77"
+      y="95.27"
+      width="3.38"
+      height="3.38"
+      transform="matrix(-0.984808, -0.173648, 0.173648, -0.984808, 196.440002, 211.100006)"
+    />
+    <rect
+      fill="#1f2121"
+      x="101.85"
+      y="98.01"
+      width="3.38"
+      height="3.38"
+      transform="matrix(-0.984808, -0.173648, 0.173648, -0.984808, 188.199997, 215.860001)"
+    />
+    <rect
+      fill="#1f2121"
+      x="99.12"
+      y="94.1"
+      width="3.38"
+      height="3.38"
+      transform="matrix(-0.984808, -0.173648, 0.173648, -0.984808, 183.440002, 207.619995)"
+    />
+    <rect
+      fill="#1f2121"
+      x="95.21"
+      y="96.84"
+      width="3.38"
+      height="3.38"
+      transform="matrix(-0.984808, -0.173648, 0.173648, -0.984808, 175.210007, 212.380005)"
+    />
+    <rect
+      fill="#1f2121"
+      x="104.59"
+      y="101.92"
+      width="3.38"
+      height="3.38"
+      transform="matrix(-0.984808, -0.173648, 0.173648, -0.984808, 192.960007, 224.100006)"
+    />
+    <rect
+      fill="#1f2121"
+      x="97.94"
+      y="100.75"
+      width="3.38"
+      height="3.38"
+      transform="matrix(-0.984808, -0.173648, 0.173648, -0.984808, 179.960007, 220.619995)"
+    />
+    <path
+      fill="#1f2121"
+      d="M95.45,91a1,1,0,0,0-1.21.85l-3.11,17.62A13.14,13.14,0,0,0,93,110.94l3.3-18.72A1,1,0,0,0,95.45,91Z"
+    />
+  </SVGIcon>
+);
+
+export default Finish;

--- a/src/components/site/linearProgress/LinearProgressMarker.jsx
+++ b/src/components/site/linearProgress/LinearProgressMarker.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+const LinearProgressMarker = ({ progress, completed, hoverable, children }) => (
+  <div
+    className={classnames('progress-linear-marker', { completed, hoverable })}
+    style={{ left: `${progress}%` }}
+  >
+    {children}
+  </div>
+);
+
+LinearProgressMarker.propTypes = {
+  progress: PropTypes.number,
+  completed: PropTypes.bool,
+  hoverable: PropTypes.bool,
+  children: PropTypes.node,
+};
+
+export default LinearProgressMarker;

--- a/src/components/site/linearProgress/index.jsx
+++ b/src/components/site/linearProgress/index.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import LinearProgressMarker from './LinearProgressMarker';
 
-const LinearProgress = ({ min, max, value, id, labelledById }) => (
+const LinearProgress = ({ min, max, value, id, labelledById, children }) => (
   <div className="progress-linear-container" id={id}>
     <div
       className="progress-linear"
@@ -12,6 +13,10 @@ const LinearProgress = ({ min, max, value, id, labelledById }) => (
       aria-labelledby={labelledById}
       style={{ width: `${value}%` }}
     ></div>
+    <LinearProgressMarker completed hoverable progress={value}>
+      <span className="progress-linear-hover-text">{`${value}%`}</span>
+    </LinearProgressMarker>
+    {children}
   </div>
 );
 
@@ -21,6 +26,7 @@ LinearProgress.propTypes = {
   value: PropTypes.number,
   id: PropTypes.string,
   labelledById: PropTypes.string,
+  children: PropTypes.node,
 };
 
 LinearProgress.defaultProps = {

--- a/src/components/site/progress/index.jsx
+++ b/src/components/site/progress/index.jsx
@@ -14,8 +14,8 @@ const Progress = ({ className, type, showQuestions, showPages }) => {
     questions: totalQuestions,
   } = totalQAsByInvestigation;
 
-  const pagesProgress = (visitedPages.length / totalPages) * 100;
-  const questionsProgress = (totalAnswered / totalQuestions) * 100;
+  const pagesProgress = Math.round((visitedPages.length / totalPages) * 100);
+  const questionsProgress = Math.round((totalAnswered / totalQuestions) * 100);
 
   const classes = classnames(className, {
     [big]: type === 'big',

--- a/src/components/site/progress/progress.module.scss
+++ b/src/components/site/progress/progress.module.scss
@@ -2,13 +2,7 @@
   .md-drawer {
     .progress-linear-container {
       width: auto;
-      height: 20px;
-      margin: 0 1em 1em;
-      background: $baseSecondary;
-
-      .progress-linear {
-        background: $awOrange;
-      }
+      margin: 1em;
     }
   }
 }

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -39,6 +39,18 @@ class Layout extends React.Component {
     this.store.addReducers();
   }
 
+  getCheckpoints = () => {
+    const { pages } = this.state;
+
+    return pages.reduce((checkpoints, page) => {
+      if (page.checkpoints && page.checkpoints.length) {
+        checkpoints.push(page.pageNumber);
+      }
+
+      return checkpoints;
+    }, []);
+  };
+
   getTotalQAs() {
     const { pages } = this.state;
     let total = 0;
@@ -118,6 +130,7 @@ class Layout extends React.Component {
       totalQAsByInvestigation: this.getTotalQAs(),
       totalQAsByPage: this.getTotalQAsByPage(),
       questionNumbersByPage: this.getQuestionNumbersByPage(),
+      checkpoints: this.getCheckpoints(),
     };
   }
 
@@ -135,7 +148,7 @@ class Layout extends React.Component {
   }
 
   render() {
-    const { pageId } = this.global;
+    const { pageId, checkpoints } = this.global;
     const { tocIsOpen, pages, investigationTitle } = this.state;
     const { children, pageContext } = this.props;
     const { investigation: contextInvestigation, env: envInvestigation } =
@@ -146,6 +159,7 @@ class Layout extends React.Component {
       <>
         <SEO title={investigationTitle || investigation || 'Investigation'} />
         <Header
+          checkpoints={checkpoints}
           investigationTitle={investigationTitle}
           logo={investigation !== 'ngss-solar-system' ? logo : null}
           pageNumber={this.getCurrentPageNumber(pages, pageId)}
@@ -183,6 +197,9 @@ export default props => (
               question {
                 id
               }
+            }
+            checkpoints {
+              ...Checkpoint
             }
           }
         }

--- a/src/state/GlobalStore.js
+++ b/src/state/GlobalStore.js
@@ -20,6 +20,7 @@ class GlobalStore {
       totalQAsByInvestigation: null,
       totalQAsByPage: null,
       questionNumbersByPage: null,
+      checkpoints: [],
       ...initialGlobals,
     };
     const { investigation } = this.emptyState;


### PR DESCRIPTION
For JIRA: "EPO-5829 #IN-REVIEW #comment Redesign progress bar"

JIRA: https://jira.lsstcorp.org/browse/EPO-5829

## What this change does ##

Redesign the progress bar in investigations for better visibility and displaying checkpoints

## Notes for reviewers ##

This change creates a new component specifically for the header progress bar that adds checkpoints along with redesigning the baseline styling for all progress bars and adding a marker onto them that when hovered will display the progress percentage.

Include an indication of how detailed a review you want on a 1-10 scale.
- 4

## Testing ##

Load an investigation and observe that checkpoints are displayed, progress through the investigation and observe the progress marker moving across the bar and the checkpoints turning from gray to green as they are reached. Hover the progress marker and observe the percentage displayed. Attempt to hover while at a checkpoint and observe that the percentage cannot be viewed at this point.

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
![image](https://user-images.githubusercontent.com/11721838/153957121-01b4b34f-4865-4945-abb1-657400b93058.png)

