### PR TITLE
[F] Implement educator mode toggle

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -6,7 +6,11 @@
   "rules": {
     "function-calc-no-unspaced-operator": true,
     "shorthand-property-no-redundant-values": true,
-    "declaration-block-no-redundant-longhand-properties": true,
+    "declaration-block-no-redundant-longhand-properties": [
+      true, {
+        "ignoreShorthands":["transition"]
+      }
+    ],
     "comment-no-empty": true,
     "max-nesting-depth": 5,
     "number-max-precision": 3,

--- a/src/assets/stylesheets/_variables.scss
+++ b/src/assets/stylesheets/_variables.scss
@@ -167,8 +167,7 @@ $baseLineHeight: 1.4;
 $verticalSpace: $baseLineHeight * 1em;
 $headingWithSpaceHeight: 90px;
 $tallestSquareWidget: calc(
-  100vh - #{$pageNavHeight} - #{$siteHeaderHeight} - #{$headingWithSpaceHeight} -
-    #{$minPadding}
+  100vh - #{$pageNavHeight} - #{$siteHeaderHeight} - #{$headingWithSpaceHeight} - #{$minPadding}
 );
 
 // $durationFast: 0.1s;

--- a/src/assets/stylesheets/components/site/_educator-mode-toggle.scss
+++ b/src/assets/stylesheets/components/site/_educator-mode-toggle.scss
@@ -1,0 +1,25 @@
+.landing-page-toggle {
+  max-width: 20rem;
+}
+
+.educator-toggle-container {
+  display: flex;
+
+  .md-switch-container {
+    flex-shrink: 0;
+  }
+}
+
+.educator-passphrase-input {
+  width: 0%;
+  margin-left: 0;
+  transition-delay: 0.25s;
+  transition-timing-function: cubic-bezier(0.39, 0.575, 0.565, 1);
+  transition-duration: 0.5s;
+  transition-property: width, margin-left;
+
+  &.expanded {
+    width: 100%;
+    margin-left: 0.5rem;
+  }
+}

--- a/src/assets/stylesheets/components/site/_index.scss
+++ b/src/assets/stylesheets/components/site/_index.scss
@@ -8,3 +8,4 @@
 @import 'progress/index';
 @import 'tables/index';
 @import 'modals';
+@import 'educator-mode-toggle';

--- a/src/assets/stylesheets/lib/_md-globals.scss
+++ b/src/assets/stylesheets/lib/_md-globals.scss
@@ -5,7 +5,7 @@
 
 :global {
   @include react-md-typography;
-  @include react-md-accessibility;
+  // @include react-md-accessibility;
   // @include react-md-grid;
   @include react-md-transitions;
   // @include react-md-inks;

--- a/src/components/pageNav/index.jsx
+++ b/src/components/pageNav/index.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-handler-names */
-import React from 'react';
+import React from 'reactn';
 import PropTypes from 'prop-types';
 import { Link } from 'gatsby';
 import classnames from 'classnames';
@@ -76,14 +76,16 @@ class PageNav extends React.PureComponent {
   }
 
   renderNavItem(type, item, baseUrl, allQuestionsAnswered = false) {
+    const { educatorMode } = this.global;
     const { link, title } = item;
     const linkIsBlank = link === '' || link === null;
     const isLinkToFirstPage = linkIsBlank && type === 'previous';
     const isLinkToLastPage = linkIsBlank && type === 'next';
     const isPrevOrAllQsA = type === 'previous' || allQuestionsAnswered;
+    const allowProgression = isPrevOrAllQsA || educatorMode;
     const buttonLink = this.getNavLink(type, item, baseUrl);
     const buttonClasses = classnames('outlined', {
-      'is-disabled': !allQuestionsAnswered && type === 'next',
+      'is-disabled': !educatorMode && !allQuestionsAnswered && type === 'next',
       'link-to-first': isLinkToFirstPage,
       'link-to-last': isLinkToLastPage,
     });
@@ -108,10 +110,12 @@ class PageNav extends React.PureComponent {
       <Button
         icon
         className={buttonClasses}
-        to={isPrevOrAllQsA ? buttonLink : null}
-        component={isPrevOrAllQsA ? Link : null}
+        to={allowProgression ? buttonLink : null}
+        component={allowProgression ? Link : null}
         iconEl={this.getButtonIconEl(type, title)}
-        onClick={isPrevOrAllQsA ? null : this.handleShowAllRequiredNotification}
+        onClick={
+          allowProgression ? null : this.handleShowAllRequiredNotification
+        }
         iconBefore={type === 'previous'}
         tooltipLabel={item.title}
         tooltipPosition="top"

--- a/src/components/site/educatorModeToggle/index.jsx
+++ b/src/components/site/educatorModeToggle/index.jsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React from 'reactn';
 import classnames from 'classnames';
 import { SelectionControl, TextField } from 'react-md';

--- a/src/components/site/educatorModeToggle/index.jsx
+++ b/src/components/site/educatorModeToggle/index.jsx
@@ -1,0 +1,73 @@
+import PropTypes from 'prop-types';
+import React from 'reactn';
+import classnames from 'classnames';
+import { SelectionControl, TextField } from 'react-md';
+
+const EDUCATOR_PASSPHRASE = '3ducatorMod3';
+
+class EducatorModeToggle extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      passphraseInput: null,
+      passphraseError: false,
+    };
+  }
+
+  handleEducatorModeChange = value => {
+    const { passphraseInput } = this.state;
+
+    if (value && passphraseInput === EDUCATOR_PASSPHRASE) {
+      this.setState({ passphraseError: false });
+      this.dispatch.setEducatorMode(true);
+    }
+
+    if (value && passphraseInput !== EDUCATOR_PASSPHRASE) {
+      this.setState({ passphraseError: true });
+      this.dispatch.setEducatorMode(false);
+    }
+
+    if (!value) {
+      this.dispatch.setEducatorMode(false);
+    }
+  };
+
+  handlePassphraseChange = value => {
+    this.setState({ passphraseInput: value });
+  };
+
+  render = () => {
+    const { educatorMode } = this.global;
+    const { passphraseError, passphraseInput } = this.state;
+
+    return (
+      <div className="educator-toggle-container">
+        <TextField
+          id="educatorModePassphrase"
+          name="educatorModePassphrase"
+          className={classnames('educator-passphrase-input', {
+            expanded: !educatorMode,
+          })}
+          error={passphraseError}
+          errorText="Incorrect passphrase"
+          fullWidth={false}
+          onChange={this.handlePassphraseChange}
+          defaultValue={passphraseInput}
+          placeholder="Passphrase"
+        />
+        <SelectionControl
+          defaultChecked={false}
+          id="educatorModeToggle"
+          name="educatorModeToggle"
+          type="switch"
+          label="Educator mode"
+          checked={educatorMode}
+          onChange={this.handleEducatorModeChange}
+        />
+      </div>
+    );
+  };
+}
+
+export default EducatorModeToggle;

--- a/src/components/site/tableOfContents/index.jsx
+++ b/src/components/site/tableOfContents/index.jsx
@@ -4,7 +4,7 @@ import { Link } from 'gatsby';
 import PropTypes from 'prop-types';
 import filter from 'lodash/filter';
 import classnames from 'classnames';
-import { Drawer } from 'react-md';
+import { Drawer, ListItemControl } from 'react-md';
 import Check from '../icons/Check';
 import Star from '../icons/Star';
 import Progress from '../progress/index.jsx';
@@ -13,6 +13,7 @@ import {
   heading,
   disabledLink,
 } from './table-of-contents.module.scss';
+import EducatorModeToggle from '../educatorModeToggle';
 
 @reactn
 class TableOfContents extends React.PureComponent {
@@ -21,6 +22,8 @@ class TableOfContents extends React.PureComponent {
     const baseUrl = linkBaseUrl && useBaseUrl ? `/${linkBaseUrl}/` : '/';
     const isActive = this.isActivePage(id);
     const allQsComplete = this.checkQAProgress(id);
+    const { educatorMode } = this.global;
+    const isDisabled = !educatorMode && !allQsComplete && !isActive;
 
     return {
       component: Link,
@@ -29,11 +32,11 @@ class TableOfContents extends React.PureComponent {
       primaryText: `${pageNumber}. ${title}`,
       leftIcon: <Check />,
       active: isActive,
-      disabled: !allQsComplete && !isActive,
+      disabled: isDisabled,
       className: classnames('toc-link', `link--page-id--${id}`, {
         'link-active': isActive,
         'qa-progress--complete': allQsComplete,
-        [disabledLink]: !allQsComplete && !isActive,
+        [disabledLink]: isDisabled,
       }),
     };
   }
@@ -61,7 +64,12 @@ class TableOfContents extends React.PureComponent {
       }),
     };
 
-    navLinks.push(qaReviewLink);
+    const educatorModeToggle = {
+      component: EducatorModeToggle,
+      primaryText: 'Educator Mode Toggle',
+    };
+
+    navLinks.push(qaReviewLink, educatorModeToggle);
     return navLinks;
   }
 

--- a/src/components/site/tableOfContents/index.jsx
+++ b/src/components/site/tableOfContents/index.jsx
@@ -4,7 +4,7 @@ import { Link } from 'gatsby';
 import PropTypes from 'prop-types';
 import filter from 'lodash/filter';
 import classnames from 'classnames';
-import { Drawer, ListItemControl } from 'react-md';
+import { Drawer } from 'react-md';
 import Check from '../icons/Check';
 import Star from '../icons/Star';
 import Progress from '../progress/index.jsx';

--- a/src/containers/LandingContainer.jsx
+++ b/src/containers/LandingContainer.jsx
@@ -7,6 +7,7 @@ import find from 'lodash/find';
 import ls from 'local-storage';
 import SEO from '../components/seo';
 import Button from '../components/site/button/index.js';
+import EducatorModeToggle from '../components/site/educatorModeToggle';
 
 @reactn
 class InvestigationsLanding extends React.PureComponent {
@@ -57,6 +58,9 @@ class InvestigationsLanding extends React.PureComponent {
               >
                 Start {envInvestigation.title} Investigation
               </Button>
+            </div>
+            <div className="space-bottom landing-page-toggle">
+              <EducatorModeToggle />
             </div>
             {isAnswers && (
               <>

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -125,6 +125,7 @@ class Layout extends React.Component {
     const { investigation, env: envInvestigation } = pageContext || {};
 
     return {
+      educatorMode: false,
       investigation: investigation || envInvestigation,
       totalPages: this.getTotalPages(),
       totalQAsByInvestigation: this.getTotalQAs(),

--- a/src/state/GlobalStore.js
+++ b/src/state/GlobalStore.js
@@ -21,6 +21,7 @@ class GlobalStore {
       totalQAsByPage: null,
       questionNumbersByPage: null,
       checkpoints: [],
+      educatorMode: null,
       ...initialGlobals,
     };
     const { investigation } = this.emptyState;
@@ -177,6 +178,13 @@ class GlobalStore {
         ...global,
         activeQuestionId: id,
         activeAnswer,
+      };
+    });
+
+    addReducer('setEducatorMode', (global, dispatch, enabled) => {
+      return {
+        ...global,
+        educatorMode: enabled,
       };
     });
   }


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-5899

## What this change does ##

Add educator mode to investigations that can be enabled by users with a password. After enabled users should be able to:

- Navigate through investigations without completing questions
- Pagination buttons are never disabled
- Table of Contents links are never disabled
- “Answer all questions” pop up is disabled
- Toggle to leave/enter educator mode on investigation landing page and in sidebar

## Notes for reviewers ##

Look for consistency in navigation with educator mode enabled/disabled and that changing the state does not leave impact on the other state i.e. that enabling educator mode then returning to student mode does not inappropriately enable links or move progression forward.

Include an indication of how detailed a review you want on a 1-10 scale.
- 5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"

## Testing ##

Start an investigation, enable educator mode using the hardcoded passphrase. Verify that each functionality listed above works. Toggle educator mode from the sidebar and verify the same. Verify that upon returning to student mode the prior functionality remains the same. 

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [ ] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
