### PR TITLE
[C] Change QaReview sorting to sectionId primary

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -60,9 +60,10 @@ exports.createPages = async ({ graphql, actions }) => {
       query {
         allPagesJson(
           filter: { investigation: { eq: "exploding-stars" } }
-          sort: { fields: [order, investigation], order: ASC }
+          sort: { fields: [sectionId, order, investigation], order: ASC }
         ) {
           nodes {
+            sectionId
             order
             id
             investigation
@@ -76,9 +77,10 @@ exports.createPages = async ({ graphql, actions }) => {
       query {
         allPagesJson(
           filter: { investigation: { eq: "window-stars" } }
-          sort: { fields: [order, investigation], order: ASC }
+          sort: { fields: [sectionId, order, investigation], order: ASC }
         ) {
           nodes {
+            sectionId
             order
             id
             investigation
@@ -92,9 +94,10 @@ exports.createPages = async ({ graphql, actions }) => {
       query {
         allPagesJson(
           filter: { investigation: { eq: "window-stars" } }
-          sort: { fields: [order, investigation], order: ASC }
+          sort: { fields: [sectionId, order, investigation], order: ASC }
         ) {
           nodes {
+            sectionId
             order
             id
             investigation
@@ -108,9 +111,10 @@ exports.createPages = async ({ graphql, actions }) => {
       query {
         allPagesJson(
           filter: { investigation: { eq: "coloring-universe" } }
-          sort: { fields: [order, investigation], order: ASC }
+          sort: { fields: [sectionId, order, investigation], order: ASC }
         ) {
           nodes {
+            sectionId
             order
             id
             investigation
@@ -124,9 +128,10 @@ exports.createPages = async ({ graphql, actions }) => {
       query {
         allPagesJson(
           filter: { investigation: { eq: "expanding-universe" } }
-          sort: { fields: [order, investigation], order: ASC }
+          sort: { fields: [sectionId, order, investigation], order: ASC }
         ) {
           nodes {
+            sectionId
             order
             id
             investigation
@@ -140,9 +145,10 @@ exports.createPages = async ({ graphql, actions }) => {
       query {
         allPagesJson(
           filter: { investigation: { eq: "observable-universe" } }
-          sort: { fields: [order, investigation], order: ASC }
+          sort: { fields: [sectionId, order, investigation], order: ASC }
         ) {
           nodes {
+            sectionId
             order
             id
             investigation
@@ -173,9 +179,10 @@ exports.createPages = async ({ graphql, actions }) => {
       query {
         allPagesJson(
           filter: { investigation: { eq: "hazardous-asteroids" } }
-          sort: { fields: [order, investigation], order: ASC }
+          sort: { fields: [sectionId, order, investigation], order: ASC }
         ) {
           nodes {
+            sectionId
             order
             id
             investigation
@@ -189,9 +196,10 @@ exports.createPages = async ({ graphql, actions }) => {
       query {
         allPagesJson(
           filter: { investigation: { eq: "demo-mini" } }
-          sort: { fields: [order, investigation], order: ASC }
+          sort: { fields: [sectionId, order, investigation], order: ASC }
         ) {
           nodes {
+            sectionId
             order
             id
             investigation
@@ -205,9 +213,10 @@ exports.createPages = async ({ graphql, actions }) => {
       query {
         allPagesJson(
           filter: { investigation: { eq: "ngss-solar-system" } }
-          sort: { fields: [order, investigation], order: ASC }
+          sort: { fields: [sectionId, order, investigation], order: ASC }
         ) {
           nodes {
+            sectionId
             order
             id
             investigation
@@ -219,8 +228,11 @@ exports.createPages = async ({ graphql, actions }) => {
   } else {
     pages = await graphql(`
       query {
-        allPagesJson(sort: { fields: [order, investigation], order: ASC }) {
+        allPagesJson(
+          sort: { fields: [sectionId, order, investigation], order: ASC }
+        ) {
           nodes {
+            sectionId
             order
             id
             investigation

--- a/src/containers/QAReviewContainer.jsx
+++ b/src/containers/QAReviewContainer.jsx
@@ -122,11 +122,8 @@ class QAReviewContainer extends React.PureComponent {
     return rw;
   }
 
-  getOrderedPages(pages, id, investigation) {
-    return filter(pages, ['investigation', id || investigation]).sort(
-      (a, b) => a.order - b.order
-    );
-  }
+  getOrderedPages = (pages, id, investigation) =>
+    filter(pages, ['investigation', id || investigation]);
 
   reviewifyPages(pages) {
     return pages.map(page => {
@@ -319,7 +316,7 @@ export const query = graphql`
         }
       }
     }
-    allPagesJson(sort: { fields: order, order: ASC }) {
+    allPagesJson(sort: { fields: [sectionId, order], order: [ASC, ASC] }) {
       nodes {
         ...PageMeta
         tables {


### PR DESCRIPTION
For git: "Resolves EPO-6062"
For JIRA: "EPO-6062 #IN-REVIEW #comment Make sectionId primary sort"

JIRA: https://jira.lsstcorp.org/browse/EPO-6062

## What this change does ##

Remove the secondary sorting in QAReviewContainer and use graphQL to sort by sectionId then order, add sectionId sorting to the gatby node build

## Notes for reviewers ##

Check that review questions display in correct order.

Include an indication of how detailed a review you want on a 1-10 scale.
- 2

## Testing ##

Can test by going to the QAReview page and verifying question order


## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
