### PR TITLE
[C] update section break layouts

### DIFF
--- a/src/components/page/sectionBreak.jsx
+++ b/src/components/page/sectionBreak.jsx
@@ -6,7 +6,7 @@ import Block from './blocks/index';
 
 class SectionBreak extends React.PureComponent {
   render() {
-    const { title, blocksGroups, shared: blockShared, t } = this.props;
+    const { blocksGroups, shared: blockShared, t } = this.props;
     const sectionBreakImagePath = '/images/section_break_celebration.gif';
 
     return (
@@ -16,7 +16,7 @@ class SectionBreak extends React.PureComponent {
           alt={t('interface::section_break.banner_alt')}
           responsive
         />
-        <h1>{title}</h1>
+        <h1>{t('interface::section_break.title')}</h1>
         {blocksGroups.map((rowBlockGroup, i) => {
           const { type, blocks } = rowBlockGroup;
           const key = `${type}-${i}`;

--- a/src/components/site/educatorModeToggle/index.jsx
+++ b/src/components/site/educatorModeToggle/index.jsx
@@ -1,6 +1,5 @@
 import React from 'reactn';
-import PropTypes from 'prop-types';
-import { Trans, withTranslation } from 'gatsby-plugin-react-i18next';
+import { Translation } from 'gatsby-plugin-react-i18next';
 import classnames from 'classnames';
 import { SelectionControl, TextField } from 'react-md';
 
@@ -39,41 +38,40 @@ class EducatorModeToggle extends React.PureComponent {
   };
 
   render = () => {
-    const { t } = this.props;
     const { educatorMode } = this.global;
     const { passphraseError, passphraseInput } = this.state;
 
     return (
-      <div className="educator-toggle-container">
-        <TextField
-          id="educatorModePassphrase"
-          name="educatorModePassphrase"
-          className={classnames('educator-passphrase-input', {
-            expanded: !educatorMode,
-          })}
-          error={passphraseError}
-          errorText={<Trans>interface::errors.passphrase.mismatch</Trans>}
-          fullWidth={false}
-          onChange={this.handlePassphraseChange}
-          defaultValue={passphraseInput}
-          placeholder={t('interface::formfields.passphrase.placeholder')}
-        />
-        <SelectionControl
-          defaultChecked={false}
-          id="educatorModeToggle"
-          name="educatorModeToggle"
-          type="switch"
-          label={<Trans>interface::educator_mode.title</Trans>}
-          checked={educatorMode}
-          onChange={this.handleEducatorModeChange}
-        />
-      </div>
+      <Translation ns={['interface']}>
+        {t => (
+          <div className="educator-toggle-container">
+            <TextField
+              id="educatorModePassphrase"
+              name="educatorModePassphrase"
+              className={classnames('educator-passphrase-input', {
+                expanded: !educatorMode,
+              })}
+              error={passphraseError}
+              errorText={t('errors.passphrase.mismatch')}
+              fullWidth={false}
+              onChange={this.handlePassphraseChange}
+              defaultValue={passphraseInput}
+              placeholder={t('formfields.passphrase.placeholder')}
+            />
+            <SelectionControl
+              defaultChecked={false}
+              id="educatorModeToggle"
+              name="educatorModeToggle"
+              type="switch"
+              label={t('educator_mode.title')}
+              checked={educatorMode}
+              onChange={this.handleEducatorModeChange}
+            />
+          </div>
+        )}
+      </Translation>
     );
   };
 }
 
-EducatorModeToggle.propTypes = {
-  t: PropTypes.func,
-};
-
-export default withTranslation()(EducatorModeToggle);
+export default EducatorModeToggle;

--- a/src/components/site/tableOfContents/index.jsx
+++ b/src/components/site/tableOfContents/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import reactn from 'reactn';
-import { Trans, Link } from 'gatsby-plugin-react-i18next';
+import { Link, withTranslation } from 'gatsby-plugin-react-i18next';
 import PropTypes from 'prop-types';
 import filter from 'lodash/filter';
 import classnames from 'classnames';
@@ -17,19 +17,36 @@ import EducatorModeToggle from '../educatorModeToggle';
 
 @reactn
 class TableOfContents extends React.PureComponent {
+  getNavLabel = (title, layout, sectionId) => {
+    const { t } = this.props;
+
+    return layout === 'SectionBreak'
+      ? t('table_of_contents.section_break', { sectionNumber: sectionId })
+      : title;
+  };
+
   getNavLink(link, useBaseUrl) {
-    const { title, pageNumber, id, investigation: linkBaseUrl, slug } = link;
+    const {
+      title,
+      pageNumber,
+      id,
+      investigation: linkBaseUrl,
+      slug,
+      layout,
+      sectionId,
+    } = link;
     const baseUrl = linkBaseUrl && useBaseUrl ? `/${linkBaseUrl}/` : '/';
     const isActive = this.isActivePage(id);
     const allQsComplete = this.checkQAProgress(id);
     const { educatorMode } = this.global;
     const isDisabled = !educatorMode && !allQsComplete && !isActive;
+    const label = this.getNavLabel(title, layout, sectionId);
 
     return {
       component: Link,
-      label: title,
+      label,
       to: baseUrl + slug,
-      primaryText: `${pageNumber}. ${title}`,
+      primaryText: `${pageNumber}. ${label}`,
       leftIcon: <Check />,
       active: isActive,
       disabled: isDisabled,
@@ -42,6 +59,7 @@ class TableOfContents extends React.PureComponent {
   }
 
   getNavLinks(pages, investigation, useBaseUrl) {
+    const { t } = this.props;
     const navLinks = [
       ...filter(pages, page => page.investigation === investigation).map(page =>
         this.getNavLink(page, useBaseUrl)
@@ -51,9 +69,9 @@ class TableOfContents extends React.PureComponent {
 
     const qaReviewLink = {
       component: Link,
-      label: <Trans>interface::actions.review_your_answers</Trans>,
+      label: t('actions.review_your_answers'),
       to: baseUrl + 'qa-review/',
-      primaryText: <Trans>interface::actions.review_your_answers</Trans>,
+      primaryText: t('actions.review_your_answers'),
       leftIcon: <Star />,
       active: true,
       disabled: false,
@@ -90,7 +108,7 @@ class TableOfContents extends React.PureComponent {
 
   render() {
     const { TEMPORARY } = Drawer.DrawerTypes;
-    const { visible, pages, investigation, isAll } = this.props;
+    const { visible, pages, investigation, isAll, t } = this.props;
 
     return (
       <Drawer
@@ -98,12 +116,10 @@ class TableOfContents extends React.PureComponent {
           <>
             <Progress type="small" />
             <hr className="md-divider" />
-            <h4 className={heading}>
-              <Trans>interface::locations.table_of_contents</Trans>
-            </h4>
+            <h4 className={heading}>{t('locations.table_of_contents')}</h4>
           </>
         }
-        aria-label={<Trans>interface::locations.table_of_contents</Trans>}
+        aria-label={t('locations.table_of_contents')}
         type={TEMPORARY}
         className={tableOfContents}
         visible={visible}
@@ -121,6 +137,7 @@ TableOfContents.propTypes = {
   toggleToc: PropTypes.func.isRequired,
   pages: PropTypes.array,
   investigation: PropTypes.string,
+  t: PropTypes.func,
 };
 
-export default TableOfContents;
+export default withTranslation('interface')(TableOfContents);

--- a/src/data/locales/en/interface.json
+++ b/src/data/locales/en/interface.json
@@ -41,6 +41,7 @@
     "answer_all_qa": "Please answer all questions before continuing to the next page."
   },
   "table_of_contents": {
+    "section_break": "End of Section {{sectionNumber}}",
     "progress": {
       "pages_visited": "Pages visited",
       "questions_answered": "Questions answered"
@@ -67,7 +68,8 @@
     "date": "Date: {{val, datetime}}"
   },
   "section_break": {
-    "banner_alt": "Animated image of fireworks"
+    "banner_alt": "Animated image of fireworks",
+    "title": "Congratulations!"
   },
   "qas": {
     "question_placeholder": "Question Placeholder: {{questionType}} Question Type does not Exist",

--- a/src/data/pages/big-view.json
+++ b/src/data/pages/big-view.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem07",
   "investigation": "solar-system",
-  "sectionId": "0",
+  "sectionId": "1",
   "order": "05",
   "title": "The Big View of the Solar System",
   "slug": "big-view/",

--- a/src/data/pages/categorizing-new-discoveries.json
+++ b/src/data/pages/categorizing-new-discoveries.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem33",
   "investigation": "solar-system",
-  "sectionId": "2",
+  "sectionId": "3",
   "order": "33",
   "title": "Categorizing your New Discoveries",
   "slug": "categorizing-new-discoveries/",

--- a/src/data/pages/characterizing-comet.json
+++ b/src/data/pages/characterizing-comet.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem11",
   "investigation": "solar-system",
-  "sectionId": "0",
+  "sectionId": "1",
   "order": "09",
   "title": "Characterizing Comets",
   "slug": "characterizing-comet/",

--- a/src/data/pages/characterizing-mba.json
+++ b/src/data/pages/characterizing-mba.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem09",
   "investigation": "solar-system",
-  "sectionId": "0",
+  "sectionId": "1",
   "order": "07",
   "title": "Characterizing Main Belt Asteroids (MBAs)",
   "slug": "characterizing-mba/",

--- a/src/data/pages/characterizing-neo.json
+++ b/src/data/pages/characterizing-neo.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem08",
   "investigation": "solar-system",
-  "sectionId": "0",
+  "sectionId": "1",
   "order": "06",
   "title": "Characterizing Near-Earth Objects (NEOs)",
   "slug": "characterizing-neo/",

--- a/src/data/pages/characterizing-orbits-4.json
+++ b/src/data/pages/characterizing-orbits-4.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem12",
   "investigation": "solar-system",
-  "sectionId": "0",
+  "sectionId": "1",
   "order": "10",
   "title": "Comparing Orbital Properties",
   "slug": "characterizing-orbits-4/",

--- a/src/data/pages/characterizing-tno.json
+++ b/src/data/pages/characterizing-tno.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem10",
   "investigation": "solar-system",
-  "sectionId": "0",
+  "sectionId": "1",
   "order": "08",
   "title": "Characterizing Trans-Neptunian Objects (TNOs)",
   "slug": "characterizing-tno/",

--- a/src/data/pages/classifying-objects-1.json
+++ b/src/data/pages/classifying-objects-1.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem23",
   "investigation": "solar-system",
-  "sectionId": "2",
+  "sectionId": "3",
   "order": "23",
   "title": "Classifying Newly Detected Solar System Objects - 2",
   "slug": "classifying-objects-1/",

--- a/src/data/pages/classifying-objects-2.json
+++ b/src/data/pages/classifying-objects-2.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem24",
   "investigation": "solar-system",
-  "sectionId": "2",
+  "sectionId": "3",
   "order": "24",
   "title": "Classifying Newly Detected Solar System Objects - 3",
   "slug": "classifying-objects-2/",

--- a/src/data/pages/classifying-objects.json
+++ b/src/data/pages/classifying-objects.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem22",
   "investigation": "solar-system",
-  "sectionId": "2",
+  "sectionId": "3",
   "order": "22",
   "title": "Classifying Newly Detected Solar System Objects - 1",
   "slug": "classifying-objects/",

--- a/src/data/pages/detecting-objects.json
+++ b/src/data/pages/detecting-objects.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem02",
   "investigation": "solar-system",
-  "sectionId": "0",
+  "sectionId": "1",
   "order": "01",
   "title": "Detecting Solar System Objects",
   "slug": "detecting-objects/",

--- a/src/data/pages/eccentricity.json
+++ b/src/data/pages/eccentricity.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem05",
   "investigation": "solar-system",
-  "sectionId": "0",
+  "sectionId": "1",
   "order": "03",
   "title": "Eccentricity",
   "slug": "eccentricity/",

--- a/src/data/pages/history-solar-system-1.json
+++ b/src/data/pages/history-solar-system-1.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem19",
   "investigation": "solar-system",
-  "sectionId": "1",
+  "sectionId": "2",
   "order": "04",
   "title": "Supporting Evidence for Solar System Formation",
   "slug": "history-solar-system-1/",

--- a/src/data/pages/history-solar-system.json
+++ b/src/data/pages/history-solar-system.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem18",
   "investigation": "solar-system",
-  "sectionId": "1",
+  "sectionId": "2",
   "order": "03",
   "title": "The Formation of the Solar System",
   "slug": "history-solar-system/",

--- a/src/data/pages/identifying-groups-1.json
+++ b/src/data/pages/identifying-groups-1.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem14",
   "investigation": "solar-system",
-  "sectionId": "1",
+  "sectionId": "2",
   "order": "00",
   "title": "Identifying Groups of Solar System Objects - 1",
   "slug": "identifying-groups-1/",

--- a/src/data/pages/identifying-groups-2.json
+++ b/src/data/pages/identifying-groups-2.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem15",
   "investigation": "solar-system",
-  "sectionId": "1",
+  "sectionId": "2",
   "order": "01",
   "title": "Identifying Groups of Solar System Objects - 2",
   "slug": "identifying-groups-2/",

--- a/src/data/pages/identifying-groups-3.json
+++ b/src/data/pages/identifying-groups-3.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem16",
   "investigation": "solar-system",
-  "sectionId": "1",
+  "sectionId": "2",
   "order": "02",
   "title": "Identifying Groups of Solar System Objects - 3",
   "slug": "identifying-groups-3/",

--- a/src/data/pages/identifying-groups-4.json
+++ b/src/data/pages/identifying-groups-4.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem17",
   "investigation": "solar-system",
-  "sectionId": "1",
+  "sectionId": "2",
   "order": "02",
   "title": "Identifying Groups of Solar System Objects - 4",
   "slug": "identifying-groups-4/",

--- a/src/data/pages/identifying-groups.json
+++ b/src/data/pages/identifying-groups.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem13",
   "investigation": "solar-system",
-  "sectionId": "0",
+  "sectionId": "1",
   "order": "11",
   "title": "Distributions of Solar System Objects",
   "slug": "identifying-groups/",

--- a/src/data/pages/inclination.json
+++ b/src/data/pages/inclination.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem06",
   "investigation": "solar-system",
-  "sectionId": "0",
+  "sectionId": "1",
   "order": "04",
   "title": "Inclination",
   "slug": "inclination/",

--- a/src/data/pages/nebula-theory.json
+++ b/src/data/pages/nebula-theory.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem19a",
   "investigation": "solar-system",
-  "sectionId": "1",
+  "sectionId": "2",
   "order": "05",
   "title": "Gravitational Interactions in the Solar System",
   "slug": "nebula-theory/",

--- a/src/data/pages/orbital-interpretation-1.json
+++ b/src/data/pages/orbital-interpretation-1.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem30",
   "investigation": "solar-system",
-  "sectionId": "2",
+  "sectionId": "3",
   "order": "30",
   "title": "Student Team B’s Drawing",
   "slug": "orbital-interpretation-1/",

--- a/src/data/pages/orbital-interpretation-2.json
+++ b/src/data/pages/orbital-interpretation-2.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem31",
   "investigation": "solar-system",
-  "sectionId": "2",
+  "sectionId": "3",
   "order": "31",
   "title": "Student Team C’s Drawing",
   "slug": "orbital-interpretation-2/",

--- a/src/data/pages/orbital-interpretation.json
+++ b/src/data/pages/orbital-interpretation.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem29",
   "investigation": "solar-system",
-  "sectionId": "2",
+  "sectionId": "3",
   "order": "29",
   "title": "Student Team A’s Drawing",
   "slug": "orbital-interpretation/",

--- a/src/data/pages/semi-major-axis.json
+++ b/src/data/pages/semi-major-axis.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem04",
   "investigation": "solar-system",
-  "sectionId": "0",
+  "sectionId": "1",
   "order": "02",
   "title": "Semi-Major Axis",
   "slug": "semi-major-axis/",

--- a/src/data/pages/solar-system-acknowledgements.json
+++ b/src/data/pages/solar-system-acknowledgements.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem37",
   "investigation": "solar-system",
-  "sectionId": "2",
+  "sectionId": "3",
   "order": "37",
   "title": "Acknowledgements",
   "slug": "acknowledgements/",

--- a/src/data/pages/solar-system-discuss-report.json
+++ b/src/data/pages/solar-system-discuss-report.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem36",
   "investigation": "solar-system",
-  "sectionId": "2",
+  "sectionId": "3",
   "order": "36",
   "title": "Reflect and Discuss",
   "slug": "solar-system-discuss-report/",

--- a/src/data/pages/solar-system-introduction.json
+++ b/src/data/pages/solar-system-introduction.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem00",
   "investigation": "solar-system",
-  "sectionId": "0",
+  "sectionId": "1",
   "order": "00",
   "title": "Introduction",
   "slug": "introduction/",

--- a/src/data/pages/solar-system-section-1.json
+++ b/src/data/pages/solar-system-section-1.json
@@ -14,5 +14,5 @@
     "link": "/identifying-groups-1/"
   },
   "layout": "SectionBreak",
-  "content": "<p>Congratulations!</p><p>You’ve successfully identified the orbital properties of the four main groups of small Solar System Objects.</p><p>Next, you will use these characteristics to classify four unknown objects, and learn how the orbits of small bodies provide evidence for the formation of the Solar System.</p>"
+  "content": "<p>You’ve successfully identified the orbital properties of the four main groups of small Solar System Objects.</p><p>Next, you will use these characteristics to classify four unknown objects, and learn how the orbits of small bodies provide evidence for the formation of the Solar System.</p>"
 }

--- a/src/data/pages/solar-system-section-1.json
+++ b/src/data/pages/solar-system-section-1.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem-1-break",
   "investigation": "solar-system",
-  "sectionId": "0",
+  "sectionId": "1",
   "order": "12",
   "title": "Progress Update",
   "slug": "section-1/",

--- a/src/data/pages/solar-system-section-2.json
+++ b/src/data/pages/solar-system-section-2.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem-3-0",
   "investigation": "solar-system",
-  "sectionId": "1",
+  "sectionId": "2",
   "order": "06",
   "title": "Progress Update",
   "slug": "section-2/",

--- a/src/data/pages/solar-system-section-2.json
+++ b/src/data/pages/solar-system-section-2.json
@@ -14,5 +14,5 @@
     "link": "/classifying-objects/"
   },
   "layout": "SectionBreak",
-  "content": "<p>Congratulations!</p><p>You’ve successfully classified the four unknown objects, and learned how gravitational interactions of small objects and their inclinations provide evidence for the formation of the Solar System.</p><p>Next, you will investigate data from a new group of Solar System objects and decide how you would communicate this new discovery.</p>"
+  "content": "<p>You’ve successfully classified the four unknown objects, and learned how gravitational interactions of small objects and their inclinations provide evidence for the formation of the Solar System.</p><p>Next, you will investigate data from a new group of Solar System objects and decide how you would communicate this new discovery.</p>"
 }

--- a/src/data/pages/solar-system-summary-6.json
+++ b/src/data/pages/solar-system-summary-6.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem34",
   "investigation": "solar-system",
-  "sectionId": "2",
+  "sectionId": "3",
   "order": "34",
   "title": "Putting it all Together",
   "slug": "solar-system-summary-6/",

--- a/src/data/pages/solar-system-summary.json
+++ b/src/data/pages/solar-system-summary.json
@@ -1,7 +1,7 @@
 {
   "id": "solarsystem28",
   "investigation": "solar-system",
-  "sectionId": "2",
+  "sectionId": "3",
   "order": "28",
   "title": "Exploring A New Class of Objects",
   "slug": "solar-system-summary/",

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -213,6 +213,7 @@ export default props => (
             investigation
             order
             sectionId
+            layout
             questionsByPage {
               question {
                 id


### PR DESCRIPTION
For git: "Resolves EPO-6063"
For JIRA: "EPO-6063 #IN-REVIEW #comment update section break layouts"

JIRA: https://jira.lsstcorp.org/browse/EPO-6063

## What this change does ##

Minor changes to section break layout, change to label for section break pages on table of contents

## Notes for reviewers ##

See code changes for description of why educator toggle button required changes

Include an indication of how detailed a review you want on a 1-10 scale.
- 3

## Testing ##

Test by clearing local cache and observing the changes in both section break pages and the table of contents

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [ ] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
Before:
![image](https://user-images.githubusercontent.com/11721838/159789221-be83fe50-d648-4dad-aa6a-371932ecf5b0.png)

After:
![image](https://user-images.githubusercontent.com/11721838/159789253-23b8f321-aaca-4283-b90b-a299f26ead3e.png)

