### PR TITLE
[C] set up URL routing for i18n

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -29,12 +29,13 @@ module.exports = {
       resolve: `gatsby-plugin-react-i18next`,
       options: {
         localeJsonSourceName: `locale`,
-        languages: [`en`, `es`],
-        defaultLanguage: `en`,
-        langKeyDefault: 'en',
+        languages: ['en', 'es'],
+        defaultLanguage: 'en',
         useLangKeyLayout: false,
+        prefixDefault: false,
         i18nextOptions: {
           debug: false,
+          fallbackLng: 'en',
           interpolation: {
             skipOnVariables: false,
             escapeValue: false, // not needed for react as it escapes by default

--- a/src/components/pageNav/index.jsx
+++ b/src/components/pageNav/index.jsx
@@ -1,8 +1,7 @@
 /* eslint-disable react/jsx-handler-names */
 import React from 'reactn';
 import PropTypes from 'prop-types';
-import { Link } from 'gatsby';
-import { Trans, withTranslation } from 'gatsby-plugin-react-i18next';
+import { Trans, withTranslation, Link } from 'gatsby-plugin-react-i18next';
 import classnames from 'classnames';
 import Button from '../site/button';
 import ButtonIcon from '../site/button/ButtonIcon';

--- a/src/components/site/tableOfContents/index.jsx
+++ b/src/components/site/tableOfContents/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import reactn from 'reactn';
-import { Link } from 'gatsby';
-import { Trans } from 'gatsby-plugin-react-i18next';
+import { Trans, Link } from 'gatsby-plugin-react-i18next';
 import PropTypes from 'prop-types';
 import filter from 'lodash/filter';
 import classnames from 'classnames';

--- a/src/containers/EndingContainer.jsx
+++ b/src/containers/EndingContainer.jsx
@@ -2,7 +2,8 @@
 import React from 'react';
 import reactn from 'reactn';
 import PropTypes from 'prop-types';
-import { Link, graphql } from 'gatsby';
+import { graphql } from 'gatsby';
+import { Link } from 'gatsby-plugin-react-i18next';
 import find from 'lodash/find';
 import ls from 'local-storage';
 import SEO from '../components/seo';
@@ -185,8 +186,8 @@ class LastPage extends React.PureComponent {
 export default LastPage;
 
 export const query = graphql`
-  query($language: String!) {
-    locales: allLocale(filter: { language: { eq: $language } }) {
+  query {
+    locales: allLocale {
       edges {
         node {
           ns

--- a/src/containers/LandingContainer.jsx
+++ b/src/containers/LandingContainer.jsx
@@ -2,8 +2,8 @@
 import React from 'react';
 import reactn from 'reactn';
 import PropTypes from 'prop-types';
-import { Link, graphql } from 'gatsby';
-import { Trans, withTranslation } from 'gatsby-plugin-react-i18next';
+import { graphql } from 'gatsby';
+import { Trans, withTranslation, Link } from 'gatsby-plugin-react-i18next';
 import find from 'lodash/find';
 import ls from 'local-storage';
 import SEO from '../components/seo';
@@ -121,8 +121,8 @@ class InvestigationsLanding extends React.PureComponent {
 export default withTranslation()(InvestigationsLanding);
 
 export const query = graphql`
-  query($language: String!) {
-    locales: allLocale(filter: { language: { eq: $language } }) {
+  query {
+    locales: allLocale {
       edges {
         node {
           ns

--- a/src/containers/PageContainer.jsx
+++ b/src/containers/PageContainer.jsx
@@ -185,8 +185,8 @@ PageContainer.propTypes = {
 };
 
 export const query = graphql`
-  query PageQuery($id: String!, $investigation: String, $language: String!) {
-    locales: allLocale(filter: { language: { eq: $language } }) {
+  query PageQuery($id: String!, $investigation: String) {
+    locales: allLocale {
       edges {
         node {
           ns

--- a/src/containers/QAReviewContainer.jsx
+++ b/src/containers/QAReviewContainer.jsx
@@ -3,8 +3,8 @@
 import React from 'react';
 import reactn from 'reactn';
 import PropTypes from 'prop-types';
-import { graphql, Link } from 'gatsby';
-import { Trans, withTranslation } from 'gatsby-plugin-react-i18next';
+import { graphql } from 'gatsby';
+import { Trans, withTranslation, Link } from 'gatsby-plugin-react-i18next';
 import find from 'lodash/find';
 import filter from 'lodash/filter';
 import Card from '../components/site/card';
@@ -306,8 +306,8 @@ QAReviewContainer.propTypes = {
 };
 
 export const query = graphql`
-  query QAReviewQuery($language: String!) {
-    locales: allLocale(filter: { language: { eq: $language } }) {
+  query QAReviewQuery {
+    locales: allLocale {
       edges {
         node {
           ns

--- a/src/data/locales/es/interface.json
+++ b/src/data/locales/es/interface.json
@@ -1,0 +1,5 @@
+{
+  "locations": {
+    "table_of_contents": "Tabla de contenido"
+  }
+}

--- a/src/pages/StyleGuide.jsx
+++ b/src/pages/StyleGuide.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'gatsby';
+import { Link } from 'gatsby-plugin-react-i18next';
 import Card from 'react-md/lib/Cards/Card';
 import CardTitle from 'react-md/lib/Cards/CardTitle';
 import CardBody from 'react-md/lib/Cards/CardText';


### PR DESCRIPTION
For git: "Resolves EPO-6066"
For JIRA: "EPO-6066 #IN-REVIEW #comment set up URL routing for i18n"

JIRA: https://jira.lsstcorp.org/browse/EPO-6066

## What this change does ##

Set up i18next to add URL path routing for locales. Redirect internal links to the appropriate URL locale. Set up fallback language for missing translations.

## Notes for reviewers ##

This change will allow switching between English and Spanish using the URL path. Only one Spanish translation is currently in place (table of contents -> Tabla de contenido) and the remaining translation keys should display their English fallback.

Include an indication of how detailed a review you want on a 1-10 scale.
- 5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"

## Testing ##

There are a couple ways to test this, some thought about the order of detecting the user's language may crop up here as well. i18n uses this default order to detect locale:

'querystring', 'cookie', 'localStorage', 'sessionStorage', 'navigator', 'htmlTag'
 
Prefixing a path with `es/` should be enough to override the locale stored locally and change the language from English to Spanish. Alternatively the local storage can be cleared and the browser language changed. This raises the question though, should browser language (navigator) take priority in the detection order over local/session/cookie storage?

Should be able to:

- click a link and be taken to a page with the same locale you are currently on
- enter a new locale into the URL path and load a different locale
- click a link and be taken to the new locale after changing the URL path
- remove the locale from the URL path and have the default locale (EN) displayed
- use a locale and show English translations for any missing keys

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [ ] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
