### PR TITLE
[C] Add orbital randomization

### DIFF
--- a/src/containers/OrbitalViewerContainer.jsx
+++ b/src/containers/OrbitalViewerContainer.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { randomIntFromInterval } from '../lib/utilities.js';
 import API from '../lib/API.js';
 import ConditionalWrapper from '../components/ConditionalWrapper';
 import NavDrawer from '../components/charts/shared/navDrawer/index.jsx';
@@ -31,11 +32,12 @@ class OrbitalViewerContainer extends React.PureComponent {
   componentDidMount() {
     const { widget, options } = this.props;
     const { source } = widget;
-    const { multiple, showUserPlot } = options || {};
+    const { multiple, showUserPlot, randomSource } = options || {};
 
     if (source) {
       API.get(source).then(response => {
-        const { data } = response;
+        console.log({ response });
+        const data = this.getOrbitData(response, randomSource);
         const activeNavIndex = multiple ? 0 : null;
         const neos = multiple ? data[activeNavIndex].data : data;
 
@@ -73,6 +75,14 @@ class OrbitalViewerContainer extends React.PureComponent {
       }));
     }
   }
+
+  getOrbitData = (response, randomSource) => {
+    const { data } = response;
+
+    return randomSource
+      ? [data[randomIntFromInterval(0, data.length - 1)]]
+      : data;
+  };
 
   getObservationAnswerData() {
     const { options, answers } = this.props;

--- a/src/containers/OrbitalViewerContainer.jsx
+++ b/src/containers/OrbitalViewerContainer.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import reactn from 'reactn';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { randomIntFromInterval } from '../lib/utilities.js';
@@ -18,6 +19,7 @@ import {
   paddedDrawerInner,
 } from '../components/visualizations/orbitalViewer/orbital-viewer.module.scss';
 
+@reactn
 class OrbitalViewerContainer extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -36,8 +38,7 @@ class OrbitalViewerContainer extends React.PureComponent {
 
     if (source) {
       API.get(source).then(response => {
-        console.log({ response });
-        const data = this.getOrbitData(response, randomSource);
+        const data = this.getSetOrbitData(response, randomSource);
         const activeNavIndex = multiple ? 0 : null;
         const neos = multiple ? data[activeNavIndex].data : data;
 
@@ -76,12 +77,25 @@ class OrbitalViewerContainer extends React.PureComponent {
     }
   }
 
-  getOrbitData = (response, randomSource) => {
+  getSetOrbitData = (response, randomSource) => {
     const { data } = response;
+    const { answers, updateAnswer } = this.props;
+    const { pageId } = this.global;
 
-    return randomSource
-      ? [data[randomIntFromInterval(0, data.length - 1)]]
-      : data;
+    if (randomSource) {
+      const orbitalSourceKey = `orbitViewer${pageId}Source`;
+
+      const savedRandomSource = answers[orbitalSourceKey];
+
+      if (savedRandomSource) {
+        return savedRandomSource.data;
+      }
+      const source = [data[randomIntFromInterval(0, data.length - 1)]];
+      updateAnswer(orbitalSourceKey, source);
+      return source;
+    }
+
+    return data;
   };
 
   getObservationAnswerData() {

--- a/src/data/pages/classifying-objects-1.json
+++ b/src/data/pages/classifying-objects-1.json
@@ -18,8 +18,9 @@
   "widgets": [
     {
       "type": "OrbitalViewer",
-      "source": "/data/neos/test-distant.json",
+      "source": "/data/neos/comets_orbit_50sample_wname2021.json",
       "options": {
+        "randomSource": true,
         "defaultZoom": 0.25,
         "noLabels": false,
         "qaReview": false

--- a/src/data/pages/classifying-objects-2.json
+++ b/src/data/pages/classifying-objects-2.json
@@ -18,8 +18,9 @@
   "widgets": [
     {
       "type": "OrbitalViewer",
-      "source": "/data/neos/test-tno.json",
+      "source": "/data/neos/TNO_orbit_50sample_wname2021.json",
       "options": {
+        "randomSource": true,
         "defaultZoom": 0.06,
         "noLabels": false,
         "qaReview": false

--- a/src/data/pages/classifying-objects.json
+++ b/src/data/pages/classifying-objects.json
@@ -18,8 +18,9 @@
   "widgets": [
     {
       "type": "OrbitalViewer",
-      "source": "/data/neos/test-mba.json",
+      "source": "/data/neos/MBA_orbit_50sample_wname2021.json",
       "options": {
+        "randomSource": true,
         "defaultZoom": 0.7,
         "noLabels": false,
         "qaReview": false


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-6065

## What this change does ##

Adds the capability to pick a random source from a dataset in the orbit viewer and preserve it using the global store

## Notes for reviewers ##

Change is limited to the `OrbitViewerContainer` component and then the 3 "classifying objects" pages

Include an indication of how detailed a review you want on a 1-10 scale.
- 3

## Testing ##

Test by visiting classifying-objects, classifying-objects-1, and classifying-objects-2 and checking that each displays an individual orbit. Revisit each page and confirm that the same orbit is displayed.

Clear the local storage and reload the application, verify that each page now displays a different orbit (it's possible one could display the same orbit again but the odds are very very low, if each one shows the same orbit you are either in danger of winning the lottery or it's not working)

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
