### PR TITLE
[F] english-spanish toggle button

### DIFF
--- a/src/assets/stylesheets/STACSS/_appearance.scss
+++ b/src/assets/stylesheets/STACSS/_appearance.scss
@@ -156,6 +156,20 @@
   }
 }
 
+.hidden {
+  display: block;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  clip: rect(0 0 0 0);
+}
+
+.hidden,
+.hide-overflow {
+  overflow: hidden;
+}
+
 // Graphs/Svgs
 // --------------------------------------------------------
 

--- a/src/assets/stylesheets/_variables.scss
+++ b/src/assets/stylesheets/_variables.scss
@@ -6,11 +6,20 @@
 //  Brand Colors
 $white: #ffffff;
 $black: #000000;
+$turquoise10: #d9f7f6;
+$turquoise20: #b2f2ef;
+$turquoise50: #00bebf;
+$turquoise55: #009fa1;
+$turquoise60: #078b8c;
+$turquoise70: #058b8c;
+$turquoise80: #117273;
+$turquoise85: #12726d;
+$turquoise90: #0c4a4c;
 $lightBlue: #bee7f5;
 $mediumBlue: #2979c1;
 $darkBlue: #074a9c;
 $brightGreen: #01bbbc;
-$mediumGreen: #058b8c;
+$mediumGreen: $turquoise70;
 $ral5018HR: #087f80;
 $boldRed: #df0039;
 $successGreen: #019105;

--- a/src/assets/stylesheets/components/site/_index.scss
+++ b/src/assets/stylesheets/components/site/_index.scss
@@ -9,3 +9,5 @@
 @import 'tables/index';
 @import 'modals';
 @import 'educator-mode-toggle';
+@import 'switch';
+@import 'language-toggle';

--- a/src/assets/stylesheets/components/site/_language-toggle.scss
+++ b/src/assets/stylesheets/components/site/_language-toggle.scss
@@ -1,0 +1,18 @@
+.language-toggle-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
+.language-toggle-label {
+  padding-inline-end: 1.75em;
+}
+
+@media only screen and (min-width: $break100) {
+  .language-toggle-label {
+    display: none;
+  }
+}

--- a/src/assets/stylesheets/components/site/_switch.scss
+++ b/src/assets/stylesheets/components/site/_switch.scss
@@ -1,0 +1,69 @@
+$switchWidth: 74px;
+$switchHeight: 39px;
+$toggleMargin: 3px;
+$toggleSize: $switchHeight - $toggleMargin * 2;
+
+.switch {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: $switchWidth;
+  height: $switchHeight;
+  padding: $toggleMargin;
+  overflow: hidden;
+  background-color: $turquoise50;
+  border: 0 solid $turquoise50;
+  border-radius: 20px;
+
+  &[aria-checked='true'] {
+    .switch-labels {
+      > .switch-label-left {
+        color: $turquoise90;
+      }
+
+      > .switch-label-right {
+        color: $white;
+      }
+    }
+
+    .switch-toggle {
+      transform: translateX($switchWidth - $toggleSize - $toggleMargin * 2);
+    }
+  }
+
+  .switch-labels {
+    position: absolute;
+    left: 0;
+    display: flex;
+    justify-content: space-around;
+    width: 100%;
+    height: 100%;
+
+    > .switch-label {
+      width: 50%;
+      height: 100%;
+      font-size: 0.727em;
+      font-weight: 700;
+      line-height: $switchHeight;
+      transition: color 0.3s ease-in-out;
+    }
+
+    > .switch-label-left {
+      color: $white;
+    }
+
+    > .switch-label-right {
+      color: $turquoise90;
+    }
+  }
+
+  .switch-toggle {
+    width: $toggleSize;
+    height: $toggleSize;
+    background: $turquoise90;
+    border: 0 solid $turquoise85;
+    border-radius: 50%;
+    transition: transform 0.3s ease-in-out;
+    transform: translateX(0);
+  }
+}

--- a/src/components/site/header/index.jsx
+++ b/src/components/site/header/index.jsx
@@ -9,6 +9,7 @@ import Menu from '../icons/Menu';
 
 import styles from './header.module.scss';
 import HeaderProgressContainer from '../../../containers/HeaderProgressContainer';
+import LanguageToggleContainer from '../../../containers/LanguageToggleContainer';
 
 class Header extends React.PureComponent {
   checkQAProgress(pageId) {
@@ -85,6 +86,7 @@ class Header extends React.PureComponent {
             </Trans>
           </span>
           <div className={styles.headerInner}>
+            <LanguageToggleContainer />
             {logo && (
               <a
                 href="http://rubineducation.org/"

--- a/src/components/site/switch/index.jsx
+++ b/src/components/site/switch/index.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Switch = ({ id, checked, onClick, leftLabel, rightLabel }) => {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      id={id}
+      onClick={onClick}
+      className="switch"
+    >
+      <div className="switch-toggle" aria-hidden></div>
+      <div className="switch-labels" aria-hidden>
+        <span className="switch-label switch-label-left">{leftLabel}</span>
+        <span className="switch-label switch-label-right">{rightLabel}</span>
+      </div>
+    </button>
+  );
+};
+
+Switch.propTypes = {
+  id: PropTypes.string,
+  checked: PropTypes.bool,
+  onClick: PropTypes.func,
+  leftLabel: PropTypes.string,
+  rightLabel: PropTypes.string,
+};
+
+export default Switch;

--- a/src/containers/LanguageToggleContainer.jsx
+++ b/src/containers/LanguageToggleContainer.jsx
@@ -1,0 +1,53 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
+import React from 'react';
+import { useTranslation, useI18next } from 'gatsby-plugin-react-i18next';
+import Switch from '../components/site/switch';
+
+const LanguageToggleContainer = () => {
+  const { t } = useTranslation('interface');
+  const { useState, useEffect, useRef } = React;
+  const {
+    language: currentLanguage,
+    defaultLanguage,
+    changeLanguage,
+  } = useI18next();
+  const [toEs, setToEs] = useState(currentLanguage !== defaultLanguage);
+  const switchCount = useRef(0);
+  const id = 'langSelect';
+
+  useEffect(() => {
+    // don't run effect for change to `toEs` on mount
+    if (switchCount.current > 0) {
+      const newLang = toEs ? 'es' : 'en';
+      changeLanguage(newLang);
+    }
+
+    switchCount.current += 1;
+  }, [toEs]);
+
+  const handleClick = () => {
+    setToEs(prevValue => !prevValue);
+  };
+
+  return (
+    <fieldset className="language-toggle-container">
+      <legend className="hidden">{t('language_toggle.legend')}</legend>
+      <label htmlFor={id}>
+        <span role="presentation" className="language-toggle-label">
+          {t('language_toggle.label')}
+        </span>
+        <span className="hidden">{t('language_toggle.espanol_site_name')}</span>
+      </label>
+
+      <Switch
+        leftLabel="EN"
+        rightLabel="ES"
+        checked={toEs}
+        onClick={handleClick}
+        id={id}
+      />
+    </fieldset>
+  );
+};
+
+export default LanguageToggleContainer;

--- a/src/data/locales/en/interface.json
+++ b/src/data/locales/en/interface.json
@@ -77,5 +77,10 @@
     "text_input": {
       "label": "Complete this statement by filling in the blank: {{labelPre}}, blank, {{labelPost}}"
     }
+  },
+  "language_toggle": {
+    "legend": "Localize site content",
+    "label": "Language",
+    "espanol_site_name": "Spanish"
   }
 }

--- a/src/data/locales/es/interface.json
+++ b/src/data/locales/es/interface.json
@@ -1,5 +1,9 @@
 {
   "locations": {
     "table_of_contents": "Tabla de contenido"
+  },
+  "language_toggle": {
+    "legend": "Localizar el contenido del sitio",
+    "espanol_site_name": "Español"
   }
 }


### PR DESCRIPTION
For git: "Resolves EPO-6124"
For JIRA: "EPO-6124 #IN-REVIEW #comment add english-spanish toggle"

JIRA: https://jira.lsstcorp.org/browse/EPO-6124

## What this change does ##

Add a toggle button to switch between English language and Spanish

## Notes for reviewers ##

Review the changes using the deployment in this PR

Include an indication of how detailed a review you want on a 1-10 scale.
- 3

## Testing ##

Test in the deployment attached to this PR. Verify that toggling the button switches between English and Spanish. When toggling to Spanish, URL's should be prepended with "es" and there is a translation for "Table of Contents" that will change based on language. 

**Feedback requested** the locale switch reloads the page, there is a very brief flash of the scrollbar displaying on the page which makes it appear to flicker. It may take some effort to trace exactly when or why this occurs during the initial page render, or alternatively the quick and dirty way would be to have the scrollbar always display. Thoughts?

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

Screenshots (optional) ##
### Before:
After:
![image](https://user-images.githubusercontent.com/11721838/161862963-d152383f-2ca2-419c-971c-8a53abdeac4f.png)

