### PR TITLE
[C] move StSS content to key-value pairs for i18n

### DIFF
--- a/src/components/charts/shared/observationsTables/ObservationsTable.jsx
+++ b/src/components/charts/shared/observationsTables/ObservationsTable.jsx
@@ -67,7 +67,7 @@ class ObservationsTable extends React.PureComponent {
   translateCells = cells => {
     const { t } = this.props;
 
-    return cells.map(t);
+    return cells ? cells.map(t) : cells;
   };
 
   render() {

--- a/src/components/charts/shared/observationsTables/ObservationsTable.jsx
+++ b/src/components/charts/shared/observationsTables/ObservationsTable.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import cloneDeep from 'lodash/cloneDeep';
-import { Trans } from 'gatsby-plugin-react-i18next';
+import { Trans, withTranslation } from 'gatsby-plugin-react-i18next';
 import Table from '../../../site/forms/table/index.jsx';
 import ObservationsTableCell from './ObservationsTableCell';
 import { tableTitle } from './observations-tables.module.scss';
@@ -34,7 +33,7 @@ class ObservationsTable extends React.PureComponent {
       );
     }
 
-    return cell;
+    return <Trans>{cell}</Trans>;
   }
 
   createEmptyRows(length) {
@@ -47,9 +46,15 @@ class ObservationsTable extends React.PureComponent {
     return rows;
   }
 
-  getRows(answers, colTitles, rowTitles, cells) {
+  getColTitles = colTitles => {
+    const { t } = this.props;
+
+    return colTitles.map(t);
+  };
+
+  getRows(answers, rowTitles, cells) {
     const rows = rowTitles
-      ? cloneDeep(rowTitles)
+      ? rowTitles.map(this.translateCells)
       : this.createEmptyRows(cells.length);
     for (let j = 0; j < rows.length; j += 1) {
       cells[j].forEach(cell => {
@@ -58,6 +63,12 @@ class ObservationsTable extends React.PureComponent {
     }
     return rows;
   }
+
+  translateCells = cells => {
+    const { t } = this.props;
+
+    return cells.map(t);
+  };
 
   render() {
     const { title, answers, rows, colTitles, rowTitles, fixed } = this.props;
@@ -71,9 +82,9 @@ class ObservationsTable extends React.PureComponent {
         )}
         <Table
           className="observations-table"
-          colTitles={colTitles}
+          colTitles={this.translateCells(colTitles)}
           includeRowTitles={!!rowTitles}
-          rows={this.getRows(answers, colTitles, rowTitles, rows)}
+          rows={this.getRows(answers, rowTitles, rows)}
           fixed={fixed}
         />
       </>
@@ -88,6 +99,7 @@ ObservationsTable.propTypes = {
   colTitles: PropTypes.array,
   rowTitles: PropTypes.array,
   fixed: PropTypes.bool,
+  t: PropTypes.func,
 };
 
-export default ObservationsTable;
+export default withTranslation()(ObservationsTable);

--- a/src/components/qas/questions/qaFillableTable/index.jsx
+++ b/src/components/qas/questions/qaFillableTable/index.jsx
@@ -2,8 +2,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import cloneDeep from 'lodash/cloneDeep';
 import { Card } from 'react-md';
+import { withTranslation } from 'gatsby-plugin-react-i18next';
 import { renderDef } from '../../../../lib/utilities.js';
 import ConditionalWrapper from '../../../ConditionalWrapper';
 import Table from '../../../site/forms/table';
@@ -58,7 +58,7 @@ class QAFillableTable extends React.PureComponent {
 
   getRows = (cells, rowTitles, questions, answers) => {
     const rows = rowTitles
-      ? cloneDeep(rowTitles)
+      ? rowTitles.map(this.translateCells)
       : this.createEmptyRows(cells.length);
     for (let j = 0; j < rows.length; j += 1) {
       cells[j].forEach(cell => {
@@ -68,8 +68,14 @@ class QAFillableTable extends React.PureComponent {
     return rows;
   };
 
+  translateCells = cells => {
+    const { t } = this.props;
+
+    return cells.map(t);
+  };
+
   render() {
-    const { questions, answers, table, questionNumber } = this.props;
+    const { questions, answers, table, questionNumber, t } = this.props;
     const { rows, colTitles, rowTitles, fixed, label } = table;
     const qaReview = questions.some(question => question.qaReview);
 
@@ -82,7 +88,7 @@ class QAFillableTable extends React.PureComponent {
     });
 
     const updatedLabel =
-      questionNumber && label ? `${questionNumber}. ${label}` : label;
+      questionNumber && label ? `${questionNumber}. ${t(label)}` : t(label);
 
     const mappedQuestions = questions.reduce((result, question) => {
       const { id } = question;
@@ -103,7 +109,7 @@ class QAFillableTable extends React.PureComponent {
             dangerouslySetInnerHTML={renderDef(updatedLabel)}
           />
           <Table
-            colTitles={colTitles}
+            colTitles={this.translateCells(colTitles)}
             includeRowTitles={!!rowTitles}
             fixed={fixed}
             rows={this.getRows(rows, rowTitles, mappedQuestions, answers)}
@@ -123,6 +129,7 @@ QAFillableTable.propTypes = {
   answerHandler: PropTypes.func,
   answers: PropTypes.object,
   table: PropTypes.object,
+  t: PropTypes.func,
 };
 
-export default QAFillableTable;
+export default withTranslation()(QAFillableTable);

--- a/src/components/qas/questions/qaSelect/index.jsx
+++ b/src/components/qas/questions/qaSelect/index.jsx
@@ -78,6 +78,17 @@ class QASelect extends React.PureComponent {
     }
   };
 
+  translateOptions = options => {
+    const { t } = this.props;
+
+    return options.map(option => {
+      return {
+        label: t(option.label),
+        value: t(option.value),
+      };
+    });
+  };
+
   render() {
     const {
       ids,
@@ -102,6 +113,7 @@ class QASelect extends React.PureComponent {
 
     const active = ids ? checkIds(ids, activeId) : activeId === id;
     const { hasFocus, answerable } = this.state;
+    const translatedOptions = this.translateOptions(options);
     const answered = !isEmpty(answer);
     const cardClasses = classnames(qaStyles.qaCard, {
       [qaStyles.active]: hasFocus,
@@ -175,14 +187,14 @@ class QASelect extends React.PureComponent {
             <Select
               id={`qa-select-${id}`}
               className={selectClasses}
-              options={options}
+              options={translatedOptions}
               label={updatedLabel || srLabel || placeholder}
-              name={label || srLabel || placeholder}
+              name={t(label) || srLabel || placeholder}
               value={answered ? answer.content || answer.data : 'DEFAULT'}
               handleBlur={this.handler}
               handleChange={this.handler}
               handleFocus={this.handler}
-              placeholder={placeholder}
+              placeholder={t(placeholder)}
               disabled={!(answerable || answered || active)}
               showLabel={!!label}
               inline={!!labelPre || !!labelPost}

--- a/src/components/site/forms/select/index.jsx
+++ b/src/components/site/forms/select/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { withTranslation } from 'gatsby-plugin-react-i18next';
 import styles from './select.module.scss';
 
 class Select extends React.PureComponent {
@@ -20,7 +19,6 @@ class Select extends React.PureComponent {
       disabled,
       showLabel,
       inline,
-      t,
     } = this.props;
 
     const classes = classnames(styles.select, className, {
@@ -29,23 +27,23 @@ class Select extends React.PureComponent {
 
     return (
       <div className={classes}>
-        {showLabel && <label htmlFor={`select-${id}`}>{t(label)}</label>}
+        {showLabel && <label htmlFor={`select-${id}`}>{label}</label>}
         <div className={styles.selectWrapper}>
           <select
             data-testid="select"
             id={`select-${id}`}
-            name={t(name)}
+            name={name}
             value={value}
             onBlur={handleBlur}
             onChange={handleChange}
             onFocus={handleFocus}
-            aria-label={t(label)}
+            aria-label={label}
             disabled={disabled || false}
             multiple={false}
           >
             {placeholder && (
               <option key="placeholder-option" value="DEFAULT" disabled>
-                {t(placeholder)}
+                {placeholder}
               </option>
             )}
             {options.map((option, i) => {
@@ -55,16 +53,16 @@ class Select extends React.PureComponent {
                   <option
                     key={option.id || `option-${i}`}
                     value={option.value}
-                    label={t(option.label)}
+                    label={option.label}
                   >
-                    {t(option.label)}
+                    {option.label}
                   </option>
                 );
               }
 
               return (
-                <option key={option} value={option} label={t(option)}>
-                  {t(option)}
+                <option key={option} value={option} label={option}>
+                  {option}
                 </option>
               );
             })}
@@ -90,7 +88,6 @@ Select.propTypes = {
   disabled: PropTypes.bool,
   showLabel: PropTypes.bool,
   inline: PropTypes.bool,
-  t: PropTypes.func,
 };
 
-export default withTranslation()(Select);
+export default Select;

--- a/src/components/site/forms/table/index.jsx
+++ b/src/components/site/forms/table/index.jsx
@@ -6,7 +6,6 @@ import TableHeader from 'react-md/lib//DataTables/TableHeader';
 import TableBody from 'react-md/lib//DataTables/TableBody';
 import TableRow from 'react-md/lib//DataTables/TableRow';
 import TableColumn from 'react-md/lib//DataTables/TableColumn';
-import { Trans } from 'gatsby-plugin-react-i18next';
 import styles from './table.module.scss';
 
 class Table extends React.PureComponent {
@@ -36,7 +35,7 @@ class Table extends React.PureComponent {
                         width: fixed ? `${100 / colTitles.length})%` : 'auto',
                       }}
                     >
-                      <Trans>{title}</Trans>
+                      {title}
                     </TableColumn>
                   );
                 })}
@@ -57,7 +56,7 @@ class Table extends React.PureComponent {
                           'row-title': includeRowTitles && j === 0,
                         })}
                       >
-                        <Trans>{col}</Trans>
+                        {col}
                       </TableColumn>
                     );
                   })}

--- a/src/containers/LandingContainer.jsx
+++ b/src/containers/LandingContainer.jsx
@@ -111,7 +111,7 @@ class InvestigationsLanding extends React.PureComponent {
               <div key={id}>
                 <Link to={`/${id}/introduction/`}>
                   <Trans values={{ investigation: title }}>
-                    interface::landing.go_to_investigation
+                    interface::actions.go_to_investigation
                   </Trans>
                 </Link>
               </div>

--- a/src/data/locales/en/astronomy.json
+++ b/src/data/locales/en/astronomy.json
@@ -29,12 +29,19 @@
   },
   "orbital_properties": {
     "inclination": "Inclination",
+    "inclination_plural": "Inclinations",
     "inclination_unit": "Inclination (degrees)",
+    "inclination_unit_plural": "Inclinations (degrees)",
     "inclination_unit_symbol": "Inclinationº",
     "eccentricity": "Eccentricity",
     "eccentricity_plural": "Eccentricities",
     "size_of_orbit": "Size of Orbit",
     "size_of_orbit_with_unit": "Size of Orbit (au)",
-    "direction_of_orbit": "Direction of Orbit"
+    "orbit_size": "Orbit size",
+    "orbit_size_plural": "Orbit sizes",
+    "orbit_size_with_unit": "Orbit size (au)",
+    "orbit_size_with_unit_plural": "Orbit sizes (au)",
+    "direction_of_orbit": "Direction of Orbit",
+    "group": "Group"
   }
 }

--- a/src/data/locales/en/interface.json
+++ b/src/data/locales/en/interface.json
@@ -18,7 +18,8 @@
     "skip_forward": "Skip Forward",
     "edit": "Edit",
     "change_answer": "Change answer",
-    "select": "Select"
+    "select": "Select",
+    "select_type": "Select a type"
   },
   "errors": {
     "qas": {
@@ -88,7 +89,18 @@
       "closer": "closer to",
       "farther": "farther from",
       "long": "long",
-      "short": "short"
+      "short": "short",
+      "almost_none": "Almost none",
+      "nearly_all": "Nearly all",
+      "roughly_half": "Roughly half",
+      "weaker": "weaker",
+      "stronger": "stronger",
+      "more": "more",
+      "less": "less",
+      "most": "most",
+      "many": "many",
+      "few": "few",
+      "none_of_the_above": "None of the above"
     }
   },
   "language_toggle": {

--- a/src/data/locales/en/solar-system.json
+++ b/src/data/locales/en/solar-system.json
@@ -13,22 +13,196 @@
       "title": "Semi-Major Axis",
       "link": "/semi-major-axis/"
     },
+    "solarsystem05": {
+      "title": "Eccentricity",
+      "link": "/eccentricity/"
+    },
     "solarsystem06": {
       "title": "Inclination",
       "link": "/inclination/"
+    },
+    "solarsystem07": {
+      "title": "The Big View of the Solar System",
+      "link": "/big-view/"
+    },
+    "solarsystem08": {
+      "title": "Characterizing Near-Earth Objects (NEOs)",
+      "link": "/characterizing-neo/"
+    },
+    "solarsystem09": {
+      "title": "Characterizing Main Belt Asteroids (MBAs)",
+      "link": "/characterizing-mba/"
+    },
+    "solarsystem10": {
+      "title": "Characterizing Trans-Neptunian Objects (TNOs)",
+      "link": "/characterizing-tno/"
+    },
+    "solarsystem11": {
+      "title": "Characterizing Comets",
+      "link": "/characterizing-comet/"
+    },
+    "solarsystem12": {
+      "title": "Comparing Orbital Properties",
+      "link": "/characterizing-orbits-4/"
+    },
+    "solarsystem13": {
+      "title": "Distributions of Solar System Objects",
+      "link": "/identifying-groups/"
+    },
+    "solar-system-1-break": {
+      "title": "Progress Update",
+      "link": "/section-1/"
+    },
+    "solarsystem14": {
+      "title": "Identifying Groups of Solar System Objects - 1",
+      "link": "/identifying-groups-1/"
+    },
+    "solarsystem15": {
+      "title": "Identifying Groups of Solar System Objects - 2",
+      "link": "/identifying-groups-2/"
+    },
+    "solarsystem16": {
+      "title": "Identifying Groups of Solar System Objects - 3",
+      "link": "/identifying-groups-3/"
+    },
+    "solarsystem17": {
+      "title": "Identifying Groups of Solar System Objects - 4",
+      "link": "/identifying-groups-4/"
+    },
+    "solarsystem18": {
+      "title": "The Formation of the Solar System",
+      "link": "/history-solar-system/"
+    },
+    "solarsystem19": {
+      "title": "Supporting Evidence for Solar System Formation",
+      "link": "/history-solar-system-1/"
+    },
+    "solarsystem19a": {
+      "title": "Gravitational Interactions in the Solar System",
+      "link": "/nebula-theory/"
+    },
+    "solar-system-2-break": {
+      "title": "Progress Update",
+      "link": "/section-2/"
+    },
+    "solarsystem22": {
+      "title": "Classifying Newly Detected Solar System Objects",
+      "link": "/classifying-objects/"
+    },
+    "solarsystem23": {
+      "title": "Classifying Newly Detected Solar System Objects - 2",
+      "link": "/classifying-objects-1/"
+    },
+    "solarsystem24": {
+      "title": "Classifying Newly Detected Solar System Objects - 3",
+      "link": "/classifying-objects-2/"
+    },
+    "solarsystem28": {
+      "title": "Exploring A New Class of Objects",
+      "link": "/solar-system-summary/"
+    },
+    "solarsystem29": {
+      "title": "Student Team A’s Drawing",
+      "link": "/orbital-interpretation/"
+    },
+    "solarsystem30": {
+      "title": "Student Team B’s Drawing",
+      "link": "/orbital-interpretation-1/"
+    },
+    "solarsystem31": {
+      "title": "Student Team C’s Drawing",
+      "link": "/orbital-interpretation-2/"
+    },
+    "solarsystem33": {
+      "title": "Categorizing your New Discoveries",
+      "link": "/categorizing-new-discoveries/"
+    },
+    "solarsystem34": {
+      "title": "Putting it all Together",
+      "link": "/solar-system-summary-6/"
+    },
+    "solarsystem36": {
+      "title": "Reflect and Discuss",
+      "link": "/solar-system-discuss-report/"
+    },
+    "solarsystem37": {
+      "title": "Acknowledgements",
+      "link": "/acknowledgements/"
     }
   },
   "content": {
     "solarsystem00": "<p>For hundreds of years we had a simple model for the objects in our Solar System: some large planets and their moons, and occasionally a passing comet. Then came the discovery of the first asteroid, Ceres, in 1801, an indication there was more going on out there than we thought. Sure enough, over the next 200 years about 800,000 small Solar System objects (which includes asteroids, comets, and trans-Neptunian objects) were discovered. At first the rate of discovery was slow, but advances in technology, which have made it possible to detect smaller and more distant objects, have sped up the process. </p> <p> Vera C. Rubin Observatory provides the most powerful observational tool we’ve ever had to study small Solar System objects; the size of the telescope’s mirrors and the sensitivity of its camera combine with the speed that the telescope surveys the night sky to help us see more objects in our Solar System than ever before. Each image taken by Rubin Observatory covers a large area of the sky, and captures light even from very faint objects, making it possible to measure the motions of millions of small Solar System objects per night. Many of these are brand new discoveries. </p> <p> In this investigation, you will explore real data from Rubin Observatory to develop a deeper understanding of how small objects are distributed throughout the Solar System. You will also examine the orbits of some newly detected Solar System objects, in order to classify them. Together, these observations will help us put together the story of how our Solar System formed, and give us insights into what we might find around other stars that have exoplanets. </p> <h3>Essential Questions</h3> <ul> <li> How do gravitational interactions affect the motion and orbital properties of small objects in the Solar System? </li> <li> What can observations of small objects reveal about the formation and history of the Solar System? </li> </ul>",
+    "solarsystem02": "<p>Each night, the Rubin Observatory LSST camera takes two images of the same star field, at least thirty minutes apart. The images are compared by computer software, and if anything has moved an <a href='http://rubineducation.org/glossary/alert' target='_blank'>alert</a> is automatically generated, and the data sent to the <a target='_blank' href='https://www.minorplanetcenter.net/about'>IAU Minor Planet Center</a> (MPC). Within hours, the MPC determines a preliminary orbit for the object.</p><p>Here are some sample observations of moving Solar System objects. Observe how each object moves through the star field. Both images cover the same area of the sky (same field of view).</p>",
+    "solarsystem04": "<p> By making a series of careful measurements, astronomers can determine the orbit for a newly discovered Solar System object. Three properties used to describe an orbit are used throughout this investigation. </p> <p> <a href='http://rubineducation.org/glossary/orbit-size' target='_blank'>Orbital size</a> is related to the orbit's <a href='http://rubineducation.org/glossary/semi-major-axis' target='_blank'>semi-major axis</a> (which is defined as half of the longest diameter of the object's orbit). It is measured in <a href='http://rubineducation.org/glossary/astronomical-unit-au' target='_blank' >astronomical units</a> (au). You can also think of the orbit's semi-major axis as its average distance from the Sun. </p>",
+    "solarsystem05": "<p><a href='http://rubineducation.org/glossary/eccentricity' target='_blank'>Eccentricity</a> describes how elliptical (i.e., oval shaped) an orbit is. Eccentricity values range from 0 to almost 1. An eccentricity of 0 describes a perfectly circular orbit. The larger the eccentricity, the more elliptical the orbit.</p>",
+    "solarsystem06": "<p><a href='http://rubineducation.org/glossary/inclination' target='_blank'>Inclination</a> (i) is the angle at which the object’s orbital plane (yellow) is tilted, relative to Earth’s orbital plane (blue) around the Sun. A value of 0° means that the object's orbit is parallel with Earth’s orbit. A value of 90° means that the object's orbit is tilted at a right angle to Earth’s orbit. If an object has an orbit with inclination greater than 90°, it will be orbiting in a direction opposite to Earth’s orbital direction.</p>",
+    "solarsystem07": "<p>Rubin Observatory will discover millions of new Solar System objects, and will provide an enormous data set that gives us a more comprehensive view of the objects’ distribution. The more we know about the distribution and properties of objects in our Solar System, the more we understand about how it formed.</p><p>Most small Solar System objects we have discovered can be classified into four groups:</p><ul><li><b>Near-Earth objects</b> (NEOs) - Objects whose orbits intersect or get very close to the orbit of Earth.</li><li><b>Main Belt asteroids</b> (MBAs) - Objects that orbit the Sun between the orbits of Mars (1.5 au) and Jupiter (5.2 au).</li><li><b>Trans-Neptunian objects</b> (TNOs) - Objects with an orbital size of 30 au or larger. Typically TNOs orbit beyond Neptune, however some may periodically come closer to the Sun than Neptune.</li><li><b>Comets</b> - Icy objects found throughout the Solar System. When orbiting close to the Sun, they develop a head and a tail formed by escaping gas and dust.</li></ul>",
+    "solarsystem08": "<p>To better understand the differences between the four groups, you will analyze orbital data for each group. The first group you will examine are the near-Earth objects (NEOs). NEOs are objects with orbits that intersect or get very close to the orbit of Earth.</p><p>Click on each icon found to the left of the histogram to examine the different orbital properties of NEOs. If you place your mouse above each bar on the histogram, the exact number of objects for the bar will appear. Some of the bars are so small that you might not notice them without looking carefully!</p><p>Decide which of the statements provided below best describes the orbital properties of NEOs.</p><p>NEOs are asteroids or comets whose orbit intersects or gets very close to the orbit of Earth.</p>",
+    "solarsystem09": "<p>MBAs are objects that orbit the Sun between the orbits of Mars (1.5 au) and Jupiter (5.2 au).</p><p>Decide which of the statements provided below best describes the orbital properties of MBAs.</p>",
+    "solarsystem10": "<p>TNOs are objects that orbit the Sun at or beyond the orbit of Neptune, at a distance of about 30 au and beyond. This area includes the Kuiper Belt and the entire region out to the inner Oort Cloud, which begins at approximately 2000 au from the Sun.</p><p>Decide which of the statements provided below best describes the orbital properties of TNOs.</p>",
+    "solarsystem11": "<p>Comets are icy objects found throughout the Solar System.</p><p>Decide which of the statements provided below best describes the orbital properties of comets.</p>",
+    "solarsystem13": "<p>Now you will explore a histogram of the number of all small Solar System objects on the y-axis vs. size of orbit on the x-axis.</p><p>Note: the scale of the y-axis changes for each of the histograms.</p><p>Click on each icon found to the left of the histogram to change the group.</p>",
+    "solarsystem14": "<p>Use the Orbit Viewer to explore the orbital characteristics of a representative set of objects from one of the four groups. All of the displayed points and their motions represent real objects. Click and drag to change the angle at which you view the orbits. You can also zoom in and out. Use the buttons in the bottom of the Orbit Viewer to play, pause, or skip forward or backward. Click the reset zoom and orientation button to return to the original view of these objects. You can change time  for the displayed motion by moving the bead on the Time Step scale located at the right of the Orbit Viewer (to a maximum of 1year/second).</p>",
+    "solarsystem15": "<p>Use the Orbit Viewer to explore this group.</p>",
+    "solarsystem18": {
+      "0": "<p>According to the solar nebula theory, a spinning cloud of dust and gas collapsed due to gravity and the young Sun began to form at the center, while dusty and icy objects began to grow by repeated collisions with each other in a flattened disk surrounding the Sun. The Sun, planets, and the disk surrounding it retained the same direction of motion as the spinning cloud that formed the Sun.</p><p>There is significant evidence to support this theory. Observations of star-forming regions reveal similar disks around young stars in other parts of the galaxy. Another piece of evidence that supports the theory is the fact that rocky planets formed close to the Sun (where temperatures were hotter) and icy planets formed at greater distances (where temperatures were much cooler).</p>",
+      "1": "<p>The <a href='http://rubineducation.org/glossary/oort-cloud' target='_blank'>Oort Cloud</a> is a spherical region of icy objects that exists at the outermost edges of the Solar System (extending from a distance of 1000 - 100,000 au), thought to have formed after the collapse of the solar nebula. One idea suggests that gravitational interactions between large planets and small Solar System objects in the early years of the Solar System slung small objects outwards to form the Oort Cloud. Another idea suggests the Sun’s gravity could have plucked some objects from other nearby solar systems.</p>"
+    },
+    "solarsystem19": "<p>We can also find evidence to support the solar nebula theory by studying the motions of objects within the Solar System. To validate this evidence, view a histogram that shows inclinations of all four groups of Solar System objects and look for overall patterns in the way objects orbit the Sun. (Remember, any inclination greater than 90 degrees indicates an object that is orbiting backwards.)</p>",
+    "solarsystem19a": {
+      "0": "<p>Although the majority of small Solar System objects have orbital characteristics that support the solar nebula theory, a small fraction of them have very eccentric or highly inclined orbits, and some even orbit the Sun in the opposite direction as the planets.</p><p>We can apply Newton’s laws and gravity to help explain these observations: </p>",
+      "1": "<p>From the early days of the Solar System to the present time, there have been many such interactions between objects and as a result, the orbits of some small objects in the Solar System are still changing.</p>"
+    },
+    "solarsystem22": "<p>Many small Solar System objects have been recently discovered by Rubin Observatory. You now have the chance to apply what you have learned to classify three such objects. Your choices for classifying each object are:</p><ul><li>MBA</li><li>TNO</li><li>NEO</li><li>Comet</li><li>None of the above</li></ul><p>Use the orbital properties in the table you constructed above to help you determine which group this newly discovered object belongs to.</p>",
+    "solarsystem23": "<p>Use the orbital properties in the table you constructed above to help you determine which group this newly discovered object belongs to.</p>",
+    "solarsystem29": "<p>The drawings above were produced by a student team to represent the data from these newly discovered small objects.</p>",
+    "solarsystem33": "<p>Here is the actual orbit viewer for this new group of objects.</p>",
+    "solarsystem37": "<p> This investigation was created by the Education and Public Outreach program of the Vera C. Rubin Observatory Construction project. In an effort to create and test this investigation prior to the start of Operations, we rely on the data of our scientific colleagues. In particular, this investigation has made use of data and/or services provided by the International Astronomical Union’s Minor Planet Center. </p> <p>We thank the following instructors who volunteered to pilot test this investigation: <ul> <li>Chris Bolhuis, Hudsonville High School, Hudsonville, MI</li> <li>Alice Few, Pierce College Ft. Steilacoom, Lakewood, WA and Tacoma Community College, Tacoma, WA</li> <li>Scott Hildreth, Chabot College, Hayward, CA</li> <li>Joe Muise, St. Thomas More Collegiate, Burnaby, British Columbia</li> <li>Denine Voegeli, Plainview-Elgin-Millville Jr. High School, Elgin, MN</li> </ul> </p> <p> The team would also like to thank Siegfried Eggl, Henry Hsieh, and Mike Kelley for useful scientific discussions in the development of this investigation. </p> <h2>Funding Support</h2> <p> Vera C. Rubin Observatory is a Federal project jointly funded by the National Science Foundation (NSF) and the Department of Energy (DOE) Office of Science, with early construction funding received from private donations through the LSST Corporation. The NSF-funded LSST (now Rubin Observatory) Project Office for construction was established as an operating center under the management of the Association of Universities for Research in Astronomy (AURA). The DOE-funded effort to build the Rubin Observatory LSST Camera (LSSTCam) is managed by SLAC National Accelerator Laboratory (SLAC). </p>",
     "solarsystem-1-break": "<p>You’ve identified the orbital properties of the four main groups of small Solar System objects.</p><p>Next, you will use these characteristics to classify four unknown objects and learn how the orbits of small bodies provide evidence for the formation of the Solar System.</p>",
     "solarsystem-2-break": "<p>You’ve classified the four unknown objects, and learned how gravitational interactions of small objects and their inclinations provide evidence for the formation of the Solar System.</p><p>Next you will investigate data from a new group of Solar System objects and decide how you would communicate this new discovery.</p>"
   },
   "images": {
     "solarsystem00": {
+      "altText": "The evolution of worlds by Lowell",
+      "figText": "Orbits of the outer planets as described in “The Evolution of Worlds,” a book published in the first decade of the 1900s by Percival Lowell."
+    },
+    "solarsystem04": {
+      "altText": "An image indicating the semi-major and semi-minor axis of an ellipse.",
+      "figText": "An image indicating the semi-major and semi-minor axis of an ellipse. Credit: Rubin Observatory."
+    },
+    "solarsystem05": {
+      "altText": "Examples of orbital ellipses with different eccentricities.",
+      "figText": "Examples of orbital ellipses with different eccentricities. Credit: Rubin Observatory"
+    },
+    "solarsystem07": {
+      "altText": "Big View of the Solar System",
+      "figText": "Credit: Rubin Observatory"
+    },
+    "solarsystem18": {
       "0": {
-        "altText": "The evolution of worlds by Lowell",
-        "figText": "Orbits of the outer planets as described in “The Evolution of Worlds,” a book published in the first decade of the 1900s by Percival Lowell."
+        "altText": "Hubble Space Telescope image shows a large, edge-on, gas-and-dust disk encircling the star Beta Pictoris. The light of the central star has been blocked out.",
+        "figText": "This Hubble Space Telescope image shows a large, edge-on, gas-and-dust disk encircling the star Beta Pictoris. The light of the central star has been blocked out. Credits: NASA, ESA, University of Arizona."
+      },
+      "1": {
+        "altText": "Illustration of the Solar System, the Kuiper Belt, and the Oort Cloud. This illustration is not to scale.",
+        "figText": "The Oort Cloud is a spherical shell of icy objects occupying the outermost regions the Solar System. (Drawing not to scale.) Credit: Rubin Observatory"
       }
+    },
+    "solarsystem19a": {
+      "altText": "Interactions between objects",
+      "figText": "How orbits of small Solar System objects can change. Credit: Rubin Observatory"
+    },
+    "solarsystem29": {
+      "altText": "A student illustration of a top and side view of the solar system showing the Sun, Mars, Jupiter, and Neptune with several orbital paths that pass between Jupiter and Neptune with a range of eccentricities and similar inclinations."
+    },
+    "solarsystem30": {
+      "altText": "A student illustration of a top and side view of the solar system showing the Sun, Mars, Jupiter, and Neptune with several orbital paths that pass between Jupiter and Neptune with a range of eccentricities and inclinations."
+    },
+    "solarsystem31": {
+      "altText": "A student illustration of a top and side view of the solar system showing the Sun, Mars, Jupiter, and Neptune with several orbital paths that pass mostly between  with a range of eccentricities and inclinations."
+    },
+    "solarsystem36": {
+      "altText": "Reflect and Discuss"
     }
   },
   "reference": {
@@ -49,6 +223,40 @@
     "2": {
       "label_pre": "The object that takes a longer time to move across the field of view is ",
       "label_post": " the Sun, "
+    },
+    "4": {
+      "label": "Eccentricity: ",
+      "options": {
+        "0": {
+          "label": "Most orbits are similar to the shape of Earth’s orbit  (0.0 - 0.3)",
+          "value": "Similar to Earth’s (0.0 - 0.3)"
+        },
+        "1": {
+          "label": "Most orbits are noticeably more elliptical than the shape of Earth’s orbit (greater than 0.3)",
+          "value": "More elliptical than Earth’s (greater than 0.3)"
+        },
+        "2": {
+          "label": "There is an equal distribution across all shapes of orbits",
+          "value": "Wide range of shapes"
+        }
+      }
+    },
+    "5": {
+      "label": "Inclination: ",
+      "options": {
+        "0": {
+          "label": "Most orbits are similar to the tilt of Earth’s orbital plane (0-20°).",
+          "value": "Similar to Earth’s (0-20°)"
+        },
+        "1": {
+          "label": "Most orbits are tilted compared to Earth’s orbital plane (more than 20°).",
+          "value": "More tilted than Earth's (more than 20°)"
+        },
+        "2": {
+          "label": "There is an equal distribution across all tilts of the orbits.",
+          "value": "Wide range in tilts"
+        }
+      }
     },
     "6": {
       "label": "Size of the orbit: ",
@@ -72,8 +280,112 @@
         }
       }
     },
+    "7": {
+      "label": "Direction of the orbit (remember, an inclination greater than 90° indicates that the object orbits the Sun opposite the direction of Earth’s orbit): ",
+      "options": {
+        "0": {
+          "label": "Almost all objects orbit the Sun in the same direction as Earth’s orbit.",
+          "value": "Same direction as Earth’s"
+        },
+        "1": {
+          "label": "More than 10% of the objects orbit the Sun in the opposite direction of Earth’s orbit (i >90°).",
+          "value": "Opposite direction as Earth’s (i >90°)"
+        }
+      }
+    },
+    "8": {
+      "placeholder": "Select best description of MBAs"
+    },
+    "12": {
+      "placeholder": "Select best description of TNOs"
+    },
+    "16": {
+      "placeholder": "Select best description of comets"
+    },
+    "20": {
+      "label": "What differences exist between the different groups of objects? Provide at least three examples."
+    },
+    "20a": {
+      "label": "Which group of objects will experience the greatest change in orbital speed during one orbital period? Explain your reasoning."
+    },
+    "200": {
+      "label": "Based on the histogram, rank the total number of small Solar System objects in each group, from most to least:"
+    },
+    "21": {
+      "label": "Rubin Observatory will make thousands of observations of our Solar System over the next decade. Do you think the number of any of these groups will change substantially?  Which one(s), and why?"
+    },
     "22": {
       "label": "Refer to your table of observations from the previous section.  Which of the four groups do you think this is? Explain your reasoning in terms of the unique set of orbital properties that defines this group of objects."
+    },
+    "23": {
+      "label": "Refer to your table of observations from the previous section.  Which of the four groups do you think this is? Explain your reasoning in terms of the unique set of orbital properties that defines this group of objects."
+    },
+    "31": {
+      "label": "Many comets are thought to originate from the Oort Cloud. Explain why these comets might have very inclined orbits compared to other types of Solar System objects."
+    },
+    "32": {
+      "labelPost": "of the small Solar System objects have orbits that lie in the orbital plane of the planets."
+    },
+    "32a": {
+      "labelPost": "of the Solar System objects orbit in the opposite direction of the planets around the Sun."
+    },
+    "33": {
+      "label": "How do the range of values for the inclination for the small objects of the Solar System support the nebular theory?"
+    },
+    "34": {
+      "label": "Imagine a close encounter in space between two objects, one with a large mass, and one with a small mass. As the objects approach each other, the gravitational forces they exert on each other must be equal according to Newton’s Third Law. Which object would experience a greater acceleration (change in its direction and speed)? Hint: think about Newton’s Second Law (force = mass X acceleration).",
+      "options": {
+        "0": "The more massive object would have its direction and speed affected more",
+        "1": "The less massive object would have its direction and speed affected more",
+        "2": "Both objects would experience the same change in direction and speed"
+      }
+    },
+    "350": {
+      "labelPre": "In addition to mass, the distance between the two objects is a factor in determining the gravitational force between the objects. Objects that are farther apart will have a ",
+      "labelPost": " gravitational force between them"
+    },
+    "351": {
+      "labelPre": "and are ",
+      "labelPost": " likely to experience a change in their orbits."
+    },
+    "46": { "label": "What is this object's name?" },
+    "47": { "label": "What type of object is this?" },
+    "48": {
+      "label": "Explain why you chose this type.  What data/evidence supports your choice?"
+    },
+    "55": {
+      "label": "Do you agree or disagree with the orbital characteristics displayed in Student Team A’s drawing above? Explain your reasoning."
+    },
+    "56": {
+      "label": "Do you agree or disagree with the orbital characteristics displayed in Student Team B’s drawing above? Explain your reasoning."
+    },
+    "57": {
+      "label": "Do you agree or disagree with the orbital characteristics displayed in Student Team C’s drawing above? Explain your reasoning."
+    },
+    "58": {
+      "labelPre": "Based on the data you have determined for this new group of objects, ",
+      "labelPost": " of them orbit the Sun in the opposite direction of Earth’s orbit."
+    },
+    "59": {
+      "label": "Based on their orbit size, between which two planets are these new objects located?"
+    },
+    "80": {
+      "label": "Which orbital characteristic(s) makes these objects different from the other four groups of objects you studied earlier? Explain."
+    },
+    "81": {
+      "label": "You are presenting the findings of your science team at an international science conference and are sharing for the first time the name you selected for your newly discovered group of solar system objects. What name do you propose?"
+    },
+    "82": {
+      "label": "Provide an explanation that defends why you chose this name."
+    },
+    "83": {
+      "label": "Your team is designing its media strategy to bring the greatest awareness to this discovery. How would you communicate your findings?"
+    },
+    "73": {
+      "label": "The asteroid `Oumuamua and comet Borisov were discovered while they were passing through our Solar System, but each came from different solar systems. Based on what you have learned about gravitational interactions, provide an explanation for how these objects were able to leave their solar systems."
+    },
+    "74": {
+      "label": "Comets often come very close to the Sun during their orbits. Comets are able to remain icy even after a close trip around the Sun. Explain how this can happen based on what you know about the changing speed of the comet during its orbit and the amount of time it spends near the Sun."
     }
   },
   "widgets": {
@@ -84,8 +396,112 @@
           "labels": {
             "y_axis": "Number of NEOs"
           }
+        },
+        "1": {
+          "title": "NEO Eccentricities"
+        },
+        "2": {
+          "title": "NEO Inclinations"
         }
       }
+    },
+    "solarsystem09": {
+      "orbital_properties": {
+        "0": {
+          "title": "MBA Orbit Sizes",
+          "labels": {
+            "y_axis": "Number of MBAs"
+          }
+        },
+        "1": {
+          "title": "MBA Eccentricities"
+        },
+        "2": {
+          "title": "MBA Inclinations"
+        }
+      }
+    },
+    "solarsystem10": {
+      "orbital_properties": {
+        "0": {
+          "title": "TNO Orbit Sizes",
+          "labels": {
+            "y_axis": "Number of TNOs"
+          }
+        },
+        "1": {
+          "title": "TNO Eccentricities"
+        },
+        "2": {
+          "title": "TNO Inclinations"
+        }
+      }
+    },
+
+    "solarsystem11": {
+      "orbital_properties": {
+        "0": {
+          "title": "Comet Orbit Sizes",
+          "labels": {
+            "y_axis": "Number of comets"
+          }
+        },
+        "1": {
+          "title": "Comet Eccentricities"
+        },
+        "2": {
+          "title": "Comet Inclinations"
+        }
+      }
+    },
+    "solarsystem13": {
+      "orbital_properties": {
+        "0": {
+          "labels": {
+            "x_axis": "NEO Orbit Sizes (au)"
+          }
+        },
+        "1": {
+          "labels": {
+            "x_axis": "MBA Orbit Sizes (au)"
+          }
+        },
+        "2": {
+          "labels": {
+            "x_axis": "TNO Orbit Sizes (au)"
+          }
+        },
+        "3": {
+          "labels": {
+            "x_axis": "Comet Orbit Sizes (au)"
+          }
+        }
+      }
+    },
+    "solarsystem19": {
+      "orbital_properties": {
+        "labels": {
+          "y_axis": "Number of Objects",
+          "tooltip": "Objects"
+        }
+      }
+    }
+  },
+  "tables": {
+    "2": {
+      "colTitles": {
+        "0": "Name",
+        "1": "Type",
+        "2": "Data/Evidence"
+      }
+    },
+    "newGroupProperties": {
+      "colTitles": {
+        "0": "New Group Property",
+        "1": "Range",
+        "2": "Most Common"
+      },
+      "label": "Your team discovers a new group of small objects that do not seem to fall into any of the four major groups you have investigated so far. Use the histograms to complete the table below."
     }
   }
 }

--- a/src/data/pages/big-view.json
+++ b/src/data/pages/big-view.json
@@ -3,23 +3,23 @@
   "investigation": "solar-system",
   "sectionOrder": 0,
   "order": "05",
-  "title": "The Big View of the Solar System",
+  "title": "solar-system::pages.solarsystem07.title",
   "slug": "big-view/",
   "previous": {
-    "title": "Inclination",
-    "link": "/inclination/"
+    "title": "solar-system::pages.solarsystem06.title",
+    "link": "solar-system::pages.solarsystem06.link"
   },
   "next": {
-    "title": "Characterizing Near-Earth Objects (NEOs)",
-    "link": "/characterizing-neo/"
+    "title": "solar-system::pages.solarsystem08.title",
+    "link": "solar-system::pages.solarsystem08.link"
   },
   "layout": "TwoCol",
   "images": [
     {
       "mediaPath": "/images/big-view.png",
-      "altText": "Big View of the Solar System",
-      "figText": "Credit: Rubin Observatory"
+      "altText": "solar-system::images.solarsystem07.altText",
+      "figText": "solar-system::images.solarsystem07.figText"
     }
   ],
-  "content": "<p>Rubin Observatory will discover millions of new Solar System objects, and will provide an enormous data set that gives us a more comprehensive view of the objects’ distribution. The more we know about the distribution and properties of objects in our Solar System, the more we understand about how it formed.</p><p>Most small Solar System objects we have discovered can be classified into four groups:</p><ul><li><b>Near-Earth objects</b> (NEOs) - Objects whose orbits intersect or get very close to the orbit of Earth.</li><li><b>Main Belt asteroids</b> (MBAs) - Objects that orbit the Sun between the orbits of Mars (1.5 au) and Jupiter (5.2 au).</li><li><b>Trans-Neptunian objects</b> (TNOs) - Objects with an orbital size of 30 au or larger. Typically TNOs orbit beyond Neptune, however some may periodically come closer to the Sun than Neptune.</li><li><b>Comets</b> - Icy objects found throughout the Solar System. When orbiting close to the Sun, they develop a head and a tail formed by escaping gas and dust.</li></ul>"
+  "content": "solar-system::content.solarsystem07"
 }

--- a/src/data/pages/categorizing-new-discoveries.json
+++ b/src/data/pages/categorizing-new-discoveries.json
@@ -3,18 +3,18 @@
   "investigation": "solar-system",
   "sectionOrder": 2,
   "order": "33",
-  "title": "Categorizing your New Discoveries",
+  "title": "solar-system::pages.solarsystem33.title",
   "slug": "categorizing-new-discoveries/",
   "previous": {
-    "title": "Student Team C’s Interpretation",
-    "link": "/orbital-interpretation-2/"
+    "title": "solar-system::pages.solarsystem31.title",
+    "link": "solar-system::pages.solarsystem31.link"
   },
   "next": {
-    "title": "Putting it all Together",
-    "link": "/solar-system-summary-6/"
+    "title": "solar-system::pages.solarsystem34.title",
+    "link": "solar-system::pages.solarsystem34.link"
   },
   "layout": "TwoCol",
-  "content": "<p>Here is the actual orbit viewer for this new group of objects.</p>",
+  "content": "solar-system::content.solarsystem33",
   "widgets": [
     {
       "type": "OrbitalViewer",
@@ -28,14 +28,22 @@
   ],
   "tables": [
     {
-      "id": "1",
+      "id": "newGroupProperties",
       "layout": {
         "row": "bottom",
         "col": "left"
       },
       "fixed": true,
-      "colTitles": ["New Group Property", "Range", "Most Common"],
-      "rowTitles": [["Orbit Size (au)"], ["Eccentricity"], ["Inclinationº"]],
+      "colTitles": [
+        "solar-system::tables.newGroupProperties.colTitles.0",
+        "solar-system::tables.newGroupProperties.colTitles.1",
+        "solar-system::tables.newGroupProperties.colTitles.2"
+      ],
+      "rowTitles": [
+        ["astronomy::orbital_properties.orbit_size_with_unit"],
+        ["astronomy::orbital_properties.eccentricity"],
+        ["astronomy::orbital_properties.inclination_unit_symbol"]
+      ],
       "rows": [
         [
           { "accessor": "range", "id": "69a" },
@@ -55,14 +63,17 @@
   ],
   "reference": [
     {
-      "title": "Planetary Orbital Sizes",
+      "layout": {
+        "col": "left",
+        "row": "bottom"
+      },
+      "title": "solar-system::reference.planetary_orbital_sizes.title",
       "button": {
         "icon": true,
-        "text": "Planetary Orbital Sizes"
+        "text": "solar-system::reference.planetary_orbital_sizes.title"
       },
-      "layout": {
-        "row": "bottom",
-        "col": "left"
+      "options": {
+        "position": "right"
       },
       "tables": [
         {
@@ -71,17 +82,20 @@
             "col": "left",
             "row": "top"
           },
-          "title": "Planetary Orbital Sizes",
-          "colTitles": ["Planet", "Orbit Size (au)"],
+          "title": "solar-system::reference.planetary_orbital_sizes.title",
+          "colTitles": [
+            "astronomy::orbital_bodies.planet",
+            "astronomy::orbital_properties.orbit_size_with_unit"
+          ],
           "rows": [
-            [{ "content": "Mercury" }, { "content": "0.4" }],
-            [{ "content": "Venus" }, { "content": "0.7" }],
-            [{ "content": "Earth" }, { "content": "1.0" }],
-            [{ "content": "Mars" }, { "content": "1.5" }],
-            [{ "content": "Jupiter" }, { "content": "5.2" }],
-            [{ "content": "Saturn" }, { "content": "9.5" }],
-            [{ "content": "Uranus" }, { "content": "19.2" }],
-            [{ "content": "Neptune" }, { "content": "30.1" }]
+            [{ "content": "astronomy::planets.mercury" }, { "content": "0.4" }],
+            [{ "content": "astronomy::planets.venus" }, { "content": "0.7" }],
+            [{ "content": "astronomy::planets.earth" }, { "content": "1.0" }],
+            [{ "content": "astronomy::planets.mars" }, { "content": "1.5" }],
+            [{ "content": "astronomy::planets.jupiter" }, { "content": "5.2" }],
+            [{ "content": "astronomy::planets.saturn" }, { "content": "9.5" }],
+            [{ "content": "astronomy::planets.uranus" }, { "content": "19.2" }],
+            [{ "content": "astronomy::planets.neptune" }, { "content": "30.1" }]
           ],
           "qaReview": false
         }
@@ -95,15 +109,24 @@
           "id": "58",
           "questionType": "select",
           "title": "Question #1",
-          "labelPre": "Based on the data you have determined for this new group of objects, ",
-          "labelPost": " of them orbit the Sun in the opposite direction of Earth’s orbit.",
+          "labelPre": "solar-system::questions.58.labelPre",
+          "labelPost": "solar-system::questions.58.labelPost",
           "options": [
-            { "label": "most", "value": "most" },
-            { "label": "many", "value": "many" },
-            { "label": "few", "value": "few" }
+            {
+              "label": "interface::qas.options.most",
+              "value": "interface::qas.options.most"
+            },
+            {
+              "label": "interface::qas.options.many",
+              "value": "interface::qas.options.many"
+            },
+            {
+              "label": "interface::qas.options.few",
+              "value": "interface::qas.options.few"
+            }
           ],
-          "placeholder": "Select",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "interface::actions.select",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]
@@ -114,7 +137,7 @@
           "id": "59",
           "questionType": "textArea",
           "title": "Question #1",
-          "label": "Based on their orbit size, between which two planets are these new objects located?",
+          "label": "solar-system::questions.59.label",
           "answerAccessor": "text"
         }
       ]

--- a/src/data/pages/characterizing-comet.json
+++ b/src/data/pages/characterizing-comet.json
@@ -3,18 +3,18 @@
   "investigation": "solar-system",
   "sectionOrder": 0,
   "order": "09",
-  "title": "Characterizing Comets",
+  "title": "solar-system::pages.solarsystem11.title",
   "slug": "characterizing-comet/",
   "previous": {
-    "title": "Characterizing Trans-Neptunian Objects (TNOs)",
-    "link": "/characterizing-tno/"
+    "title": "solar-system::pages.solarsystem10.title",
+    "link": "solar-system::pages.solarsystem10.link"
   },
   "next": {
-    "title": "Comparing Orbital Properties",
-    "link": "/characterizing-orbits-4/"
+    "title": "solar-system::pages.solarsystem12.title",
+    "link": "solar-system::pages.solarsystem12.link"
   },
   "layout": "TwoCol",
-  "content": "<p>Comets are icy objects found throughout the Solar System.</p><p>Decide which of the statements provided below best describes the orbital properties of comets.</p>",
+  "content": "solar-system::content.solarsystem11",
   "tables": [
     {
       "id": "1",
@@ -24,13 +24,18 @@
       },
       "fixed": true,
       "colTitles": [
-        "Group",
-        "Size of Orbit",
-        "Eccentricity",
-        "Inclination",
-        "Direction of Orbit"
+        "astronomy::orbital_properties.group",
+        "astronomy::orbital_properties.size_of_orbit",
+        "astronomy::orbital_properties.eccentricity",
+        "astronomy::orbital_properties.inclination",
+        "astronomy::orbital_properties.direction_of_orbit"
       ],
-      "rowTitles": [["NEOs"], ["MBAs"], ["TNOs"], ["Comets"]],
+      "rowTitles": [
+        ["astronomy::orbital_bodies.neo_abbrev_plural"],
+        ["astronomy::orbital_bodies.mba_abbrev_plural"],
+        ["astronomy::orbital_bodies.tno_abbrev_plural"],
+        ["astronomy::orbital_bodies.comet_plural"]
+      ],
       "rows": [
         [
           { "accessor": "data", "id": "6" },
@@ -68,42 +73,51 @@
           "type": "OrbitalProperties",
           "source": "/data/neos/comets_semimajor_axis_hist.json",
           "options": {
-            "title": "Comet Orbit Sizes",
-            "xAxisLabel": "Orbit Sizes (au)",
+            "title": "solar-system::widgets.solarsystem11.orbital_properties.0.title",
+            "xAxisLabel": "astronomy::orbital_properties.size_of_orbit_with_unit",
             "xValueAccessor": "semimajor_axis",
-            "yAxisLabel": "Number of comets",
+            "yAxisLabel": "solar-system::widgets.solarsystem11.orbital_properties.0.labels.y_axis",
             "domain": [[0, 100], []],
             "bins": 20,
             "tooltipAccessors": ["countOfTotal", "semimajor_axis"],
-            "tooltipLabels": ["Comets", "Orbit Size (au)"]
+            "tooltipLabels": [
+              "astronomy::orbital_bodies.comet_plural",
+              "astronomy::orbital_properties.size_of_orbit_with_unit"
+            ]
           }
         },
         {
           "type": "OrbitalProperties",
           "source": "/data/neos/comets_eccentricity_hist.json",
           "options": {
-            "title": "Comet Eccentricities",
-            "xAxisLabel": "Eccentricities",
+            "title": "solar-system::widgets.solarsystem11.orbital_properties.1.title",
+            "xAxisLabel": "astronomy::orbital_properties.eccentricity_plural",
             "xValueAccessor": "eccentricity",
-            "yAxisLabel": "Number of comets",
+            "yAxisLabel": "solar-system::widgets.solarsystem11.orbital_properties.0.labels.y_axis",
             "domain": [[0, 1], []],
             "bins": 10,
             "tooltipAccessors": ["countOfTotal", "eccentricity"],
-            "tooltipLabels": ["Comets", "Eccentricity"]
+            "tooltipLabels": [
+              "astronomy::orbital_bodies.comet_plural",
+              "astronomy::orbital_properties.eccentricity"
+            ]
           }
         },
         {
           "type": "OrbitalProperties",
           "source": "/data/neos/comets_inclination_hist.json",
           "options": {
-            "title": "Comet Inclinations",
-            "xAxisLabel": "Inclinations (degrees)",
+            "title": "solar-system::widgets.solarsystem11.orbital_properties.1.title",
+            "xAxisLabel": "astronomy::orbital_properties.inclination_unit",
             "xValueAccessor": "inclination",
-            "yAxisLabel": "Number of comets",
+            "yAxisLabel": "solar-system::widgets.solarsystem11.orbital_properties.0.labels.y_axis",
             "domain": [[0, 180], []],
             "bins": 9,
             "tooltipAccessors": ["countOfTotal", "inclination"],
-            "tooltipLabels": ["Comets", "Inclination (degrees)"]
+            "tooltipLabels": [
+              "astronomy::orbital_bodies.comet_plural",
+              "astronomy::orbital_properties.inclination_unit"
+            ]
           }
         }
       ],
@@ -117,27 +131,27 @@
           "id": "18",
           "questionType": "select",
           "title": "Question #1",
-          "label": "Size of the orbit: ",
+          "label": "solar-system::questions.6.label",
           "options": [
             {
-              "label": "All of the orbits are within the inner Solar System (between 0.5 - 4 au).",
-              "value": "Within inner Solar System (between 0.5 - 4 au)"
+              "label": "solar-system::questions.6.options.0.label",
+              "value": "solar-system::questions.6.options.0.value"
             },
             {
-              "label": "All of the orbits are within the inner Solar System (between 1.5 - 5.2 au).",
-              "value": "Within inner Solar System (between 1.5 - 5.2 au)"
+              "label": "solar-system::questions.6.options.1.label",
+              "value": "solar-system::questions.6.options.1.value"
             },
             {
-              "label": "The orbit sizes are 30 au or larger, and objects typically orbit beyond Neptune.",
-              "value": "In the outer Solar System (30 au or larger)"
+              "label": "solar-system::questions.6.options.2.label",
+              "value": "solar-system::questions.6.options.2.value"
             },
             {
-              "label": "The orbit sizes span both the inner and outer Solar System, beyond 30 au.",
-              "value": "Span inner and outer Solar System (beyond 30 au)"
+              "label": "solar-system::questions.6.options.3.label",
+              "value": "solar-system::questions.6.options.3.value"
             }
           ],
-          "placeholder": "Select best description of comets",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "solar-system::questions.16.placeholder",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]
@@ -148,23 +162,23 @@
           "id": "16",
           "questionType": "select",
           "title": "Question #1",
-          "label": "Eccentricity: ",
+          "label": "solar-system::questions.4.label",
           "options": [
             {
-              "label": "Most orbits are similar to the shape of Earth’s orbit  (0.0 - 0.3)",
-              "value": "Similar to Earth’s (0.0 - 0.3)"
+              "label": "solar-system::questions.4.options.0.label",
+              "value": "solar-system::questions.4.options.0.value"
             },
             {
-              "label": "Most orbits are noticeably more elliptical than the shape of Earth’s orbit (greater than 0.3)",
-              "value": "More elliptical than Earth’s (greater than 0.3)"
+              "label": "solar-system::questions.4.options.1.label",
+              "value": "solar-system::questions.4.options.1.value"
             },
             {
-              "label": "There is an equal distribution across all shapes of orbits",
-              "value": "Wide range of shapes"
+              "label": "solar-system::questions.4.options.2.label",
+              "value": "solar-system::questions.4.options.2.value"
             }
           ],
-          "placeholder": "Select best description of comets",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "solar-system::questions.16.placeholder",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]
@@ -175,23 +189,23 @@
           "id": "17",
           "questionType": "select",
           "title": "Question #1",
-          "label": "Inclination: ",
+          "label": "solar-system::questions.5.label",
           "options": [
             {
-              "label": "Most orbits are similar to the tilt of Earth’s orbital plane (0-20°).",
-              "value": "Similar to Earth’s (0-20°)"
+              "label": "solar-system::questions.5.options.0.label",
+              "value": "solar-system::questions.5.options.0.value"
             },
             {
-              "label": "Most orbits are tilted compared to Earth’s orbital plane (more than 20°).",
-              "value": "More tilted than Earth's (more than 20°)"
+              "label": "solar-system::questions.5.options.1.label",
+              "value": "solar-system::questions.5.options.1.value"
             },
             {
-              "label": "There is an equal distribution across all tilts of the orbits.",
-              "value": "Wide range in tilts"
+              "label": "solar-system::questions.5.options.2.label",
+              "value": "solar-system::questions.5.options.2.value"
             }
           ],
-          "placeholder": "Select best description of comets",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "solar-system::questions.16.placeholder",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]
@@ -202,19 +216,19 @@
           "id": "19",
           "questionType": "select",
           "title": "Question #1",
-          "label": "Direction of the orbit (remember, an inclination greater than 90° indicates that the object orbits the Sun opposite the direction of Earth’s orbit): ",
+          "label": "solar-system::questions.7.label",
           "options": [
             {
-              "label": "Almost all objects orbit the Sun in the same direction as Earth’s orbit.",
-              "value": "Same direction as Earth’s"
+              "label": "solar-system::questions.7.options.0.label",
+              "value": "solar-system::questions.7.options.0.value"
             },
             {
-              "label": "More than 10% of the objects orbit the Sun in the opposite direction of Earth’s orbit (i >90°).",
-              "value": "Opposite direction as Earth’s (i >90°)"
+              "label": "solar-system::questions.7.options.1.label",
+              "value": "solar-system::questions.7.options.1.value"
             }
           ],
-          "placeholder": "Select best description of comets",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "solar-system::questions.16.placeholder",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]

--- a/src/data/pages/characterizing-mba.json
+++ b/src/data/pages/characterizing-mba.json
@@ -3,18 +3,18 @@
   "investigation": "solar-system",
   "sectionOrder": 0,
   "order": "07",
-  "title": "Characterizing Main Belt Asteroids (MBAs)",
+  "title": "solar-system::pages.solarsystem09.title",
   "slug": "characterizing-mba/",
   "previous": {
-    "title": "Characterizing Near-Earth Objects (NEOs)",
-    "link": "/characterizing-neo/"
+    "title": "solar-system::pages.solarsystem08.title",
+    "link": "solar-system::pages.solarsystem08.link"
   },
   "next": {
-    "title": "Characterizing Trans-Neptunian Objects (TNOs)",
-    "link": "/characterizing-tno/"
+    "title": "solar-system::pages.solarsystem10.title",
+    "link": "solar-system::pages.solarsystem10.link"
   },
   "layout": "TwoCol",
-  "content": "<p>MBAs are objects that orbit the Sun between the orbits of Mars (1.5 au) and Jupiter (5.2 au).</p><p>Decide which of the statements provided below best describes the orbital properties of MBAs.</p>",
+  "content": "solar-system::content.solarsystem09",
   "tables": [
     {
       "id": "1",
@@ -24,13 +24,18 @@
       },
       "fixed": true,
       "colTitles": [
-        "Group",
-        "Size of Orbit",
-        "Eccentricity",
-        "Inclination",
-        "Direction of Orbit"
+        "astronomy::orbital_properties.group",
+        "astronomy::orbital_properties.size_of_orbit",
+        "astronomy::orbital_properties.eccentricity",
+        "astronomy::orbital_properties.inclination",
+        "astronomy::orbital_properties.direction_of_orbit"
       ],
-      "rowTitles": [["NEOs"], ["MBAs"], ["TNOs"], ["Comets"]],
+      "rowTitles": [
+        ["astronomy::orbital_bodies.neo_abbrev_plural"],
+        ["astronomy::orbital_bodies.mba_abbrev_plural"],
+        ["astronomy::orbital_bodies.tno_abbrev_plural"],
+        ["astronomy::orbital_bodies.comet_plural"]
+      ],
       "rows": [
         [
           { "accessor": "data", "id": "6" },
@@ -68,42 +73,51 @@
           "type": "OrbitalProperties",
           "source": "/data/neos/mba_semimajor_axis_hist.json",
           "options": {
-            "title": "MBA Orbit Sizes",
-            "xAxisLabel": "Orbit Sizes (au)",
-            "yAxisLabel": "Number of MBAs",
+            "title": "solar-system::widgets.solarsystem09.orbital_properties.0.title",
+            "xAxisLabel": "astronomy::orbital_properties.size_of_orbit_with_unit",
+            "yAxisLabel": "solar-system::widgets.solarsystem09.orbital_properties.0.labels.y_axis",
             "xValueAccessor": "semimajor_axis",
             "domain": [[0, 10], []],
             "bins": 20,
             "tooltipAccessors": ["countOfTotal", "semimajor_axis"],
-            "tooltipLabels": ["MBAs", "Orbit Size (au)"]
+            "tooltipLabels": [
+              "astronomy::orbital_bodies.mba_abbrev_plural",
+              "astronomy::orbital_properties.size_of_orbit_with_unit"
+            ]
           }
         },
         {
           "type": "OrbitalProperties",
           "source": "/data/neos/mba_eccentricity_hist.json",
           "options": {
-            "title": "MBA Eccentricities",
-            "xAxisLabel": "Eccentricities",
-            "yAxisLabel": "Number of MBAs",
+            "title": "solar-system::widgets.solarsystem09.orbital_properties.1.title",
+            "xAxisLabel": "astronomy::orbital_properties.eccentricity_plural",
+            "yAxisLabel": "solar-system::widgets.solarsystem09.orbital_properties.0.labels.y_axis",
             "xValueAccessor": "eccentricity",
             "domain": [[0, 1], []],
             "bins": 10,
             "tooltipAccessors": ["countOfTotal", "eccentricity"],
-            "tooltipLabels": ["MBAs", "Eccentricity"]
+            "tooltipLabels": [
+              "astronomy::orbital_bodies.mba_abbrev_plural",
+              "astronomy::orbital_properties.eccentricity"
+            ]
           }
         },
         {
           "type": "OrbitalProperties",
           "source": "/data/neos/mba_inclination_hist.json",
           "options": {
-            "title": "MBA Inclinations",
-            "xAxisLabel": "Inclinations (degrees)",
-            "yAxisLabel": "Number of MBAs",
+            "title": "solar-system::widgets.solarsystem09.orbital_properties.2.title",
+            "xAxisLabel": "astronomy::orbital_properties.inclination_unit",
+            "yAxisLabel": "solar-system::widgets.solarsystem09.orbital_properties.0.labels.y_axis",
             "xValueAccessor": "inclination",
             "domain": [[0, 180], []],
             "bins": 9,
             "tooltipAccessors": ["countOfTotal", "inclination"],
-            "tooltipLabels": ["MBAs", "Inclination (degrees)"]
+            "tooltipLabels": [
+              "astronomy::orbital_bodies.mba_abbrev_plural",
+              "astronomy::orbital_properties.inclination_unit"
+            ]
           }
         }
       ],
@@ -117,27 +131,27 @@
           "id": "10",
           "questionType": "select",
           "title": "Question #1",
-          "label": "Size of the orbit: ",
+          "label": "solar-system::questions.6.label",
           "options": [
             {
-              "label": "All of the orbits are within the inner Solar System (between 0.5 - 4 au).",
-              "value": "Within inner Solar System (between 0.5 - 4 au)"
+              "label": "solar-system::questions.6.options.0.label",
+              "value": "solar-system::questions.6.options.0.value"
             },
             {
-              "label": "All of the orbits are within the inner Solar System (between 1.5 - 5.2 au).",
-              "value": "Within inner Solar System (between 1.5 - 5.2 au)"
+              "label": "solar-system::questions.6.options.1.label",
+              "value": "solar-system::questions.6.options.1.value"
             },
             {
-              "label": "The orbit sizes are 30 au or larger, and objects typically orbit beyond Neptune.",
-              "value": "In the outer Solar System (30 au or larger)"
+              "label": "solar-system::questions.6.options.2.label",
+              "value": "solar-system::questions.6.options.2.value"
             },
             {
-              "label": "The orbit sizes span both the inner and outer Solar System, beyond 30 au.",
-              "value": "Span inner and outer Solar System (beyond 30 au)"
+              "label": "solar-system::questions.6.options.3.label",
+              "value": "solar-system::questions.6.options.3.value"
             }
           ],
-          "placeholder": "Select best description of MBAs",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "solar-system::questions.8.placeholder",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]
@@ -148,23 +162,23 @@
           "id": "8",
           "questionType": "select",
           "title": "Question #1",
-          "label": "Eccentricity: ",
+          "label": "solar-system::questions.4.label",
           "options": [
             {
-              "label": "Most orbits are similar to the shape of Earth’s orbit  (0.0 - 0.3)",
-              "value": "Similar to Earth’s (0.0 - 0.3)"
+              "label": "solar-system::questions.4.options.0.label",
+              "value": "solar-system::questions.4.options.0.value"
             },
             {
-              "label": "Most orbits are noticeably more elliptical than the shape of Earth’s orbit (greater than 0.3)",
-              "value": "More elliptical than Earth’s (greater than 0.3)"
+              "label": "solar-system::questions.4.options.1.label",
+              "value": "solar-system::questions.4.options.1.value"
             },
             {
-              "label": "There is an equal distribution across all shapes of orbits",
-              "value": "Wide range of shapes"
+              "label": "solar-system::questions.4.options.2.label",
+              "value": "solar-system::questions.4.options.2.value"
             }
           ],
-          "placeholder": "Select best description of MBAs",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "solar-system::questions.8.placeholder",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]
@@ -175,23 +189,23 @@
           "id": "9",
           "questionType": "select",
           "title": "Question #1",
-          "label": "Inclination: ",
+          "label": "solar-system::questions.5.label",
           "options": [
             {
-              "label": "Most orbits are similar to the tilt of Earth’s orbital plane (0-20°).",
-              "value": "Similar to Earth’s (0-20°)"
+              "label": "solar-system::questions.5.options.0.label",
+              "value": "solar-system::questions.5.options.0.value"
             },
             {
-              "label": "Most orbits are tilted compared to Earth’s orbital plane (more than 20°).",
-              "value": "More tilted than Earth's (more than 20°)"
+              "label": "solar-system::questions.5.options.1.label",
+              "value": "solar-system::questions.5.options.1.value"
             },
             {
-              "label": "There is an equal distribution across all tilts of the orbits.",
-              "value": "Wide range in tilts"
+              "label": "solar-system::questions.5.options.2.label",
+              "value": "solar-system::questions.5.options.2.value"
             }
           ],
-          "placeholder": "Select best description of MBAs",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "solar-system::questions.8.placeholder",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]
@@ -202,19 +216,19 @@
           "id": "11",
           "questionType": "select",
           "title": "Question #1",
-          "label": "Direction of the orbit (remember, an inclination greater than 90° indicates that the object orbits the Sun opposite the direction of Earth’s orbit): ",
+          "label": "solar-system::questions.7.label",
           "options": [
             {
-              "label": "Almost all objects orbit the Sun in the same direction as Earth’s orbit.",
-              "value": "Same direction as Earth’s"
+              "label": "solar-system::questions.7.options.0.label",
+              "value": "solar-system::questions.7.options.0.value"
             },
             {
-              "label": "More than 10% of the objects orbit the Sun in the opposite direction of Earth’s orbit (i >90°).",
-              "value": "Opposite direction as Earth’s (i >90°)"
+              "label": "solar-system::questions.7.options.1.label",
+              "value": "solar-system::questions.7.options.1.value"
             }
           ],
-          "placeholder": "Select best description of MBAs",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "solar-system::questions.8.placeholder",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]

--- a/src/data/pages/characterizing-neo.json
+++ b/src/data/pages/characterizing-neo.json
@@ -3,18 +3,18 @@
   "investigation": "solar-system",
   "sectionOrder": 0,
   "order": "06",
-  "title": "Characterizing Near-Earth Objects (NEOs)",
+  "title": "solar-system::pages.solarsystem08.title",
   "slug": "characterizing-neo/",
   "previous": {
-    "title": "The Big View of the Solar System",
-    "link": "/big-view/"
+    "title": "solar-system::pages.solarsystem07.title",
+    "link": "solar-system::pages.solarsystem07.link"
   },
   "next": {
-    "title": "Characterizing Main Belt Asteroids (MBAs)",
-    "link": "/characterizing-mba/"
+    "title": "solar-system::pages.solarsystem09.title",
+    "link": "solar-system::pages.solarsystem09.link"
   },
   "layout": "TwoCol",
-  "content": "<p>To better understand the differences between the four groups, you will analyze orbital data for each group. The first group you will examine are the near-Earth objects (NEOs). NEOs are objects with orbits that intersect or get very close to the orbit of Earth.</p><p>Click on each icon found to the left of the histogram to examine the different orbital properties of NEOs. If you place your mouse above each bar on the histogram, the exact number of objects for the bar will appear. Some of the bars are so small that you might not notice them without looking carefully!</p><p>Decide which of the statements provided below best describes the orbital properties of NEOs.</p><p>NEOs are asteroids or comets whose orbit intersects or gets very close to the orbit of Earth.</p>",
+  "content": "solar-system::content.solarsystem08",
   "tables": [
     {
       "id": "1",
@@ -24,7 +24,7 @@
       },
       "fixed": true,
       "colTitles": [
-        "Group",
+        "astronomy::orbital_properties.group",
         "astronomy::orbital_properties.size_of_orbit",
         "astronomy::orbital_properties.eccentricity",
         "astronomy::orbital_properties.inclination",
@@ -76,7 +76,7 @@
             "title": "solar-system::widgets.solarsystem08.orbital_properties.0.title",
             "xAxisLabel": "astronomy::orbital_properties.size_of_orbit_with_unit",
             "xValueAccessor": "semimajor_axis",
-            "yAxisLabel": "astronomy::widgets.solarsystem08.orbital_properties.0.labels.y_axis",
+            "yAxisLabel": "solar-system::widgets.solarsystem08.orbital_properties.0.labels.y_axis",
             "domain": [[0, 10], []],
             "bins": 20,
             "tooltipAccessors": ["countOfTotal", "semimajor_axis"],
@@ -90,10 +90,10 @@
           "type": "OrbitalProperties",
           "source": "/data/neos/neo_eccentricity_hist.json",
           "options": {
-            "title": "NEO Eccentricities",
+            "title": "solar-system::widgets.solarsystem08.orbital_properties.1.title",
             "xAxisLabel": "astronomy::orbital_properties.eccentricity_plural",
             "xValueAccessor": "eccentricity",
-            "yAxisLabel": "astronomy::widgets.solarsystem08.orbital_properties.0.labels.y_axis",
+            "yAxisLabel": "solar-system::widgets.solarsystem08.orbital_properties.0.labels.y_axis",
             "domain": [[0, 1], []],
             "bins": 10,
             "tooltipAccessors": ["countOfTotal", "eccentricity"],
@@ -107,10 +107,10 @@
           "type": "OrbitalProperties",
           "source": "/data/neos/neo_inclination_hist.json",
           "options": {
-            "title": "NEO Inclinations",
-            "xAxisLabel": "Inclinations (degrees)",
+            "title": "solar-system::widgets.solarsystem08.orbital_properties.2.title",
+            "xAxisLabel": "astronomy::orbital_properties.inclination_unit",
             "xValueAccessor": "inclination",
-            "yAxisLabel": "astronomy::widgets.solarsystem08.orbital_properties.0.labels.y_axis",
+            "yAxisLabel": "solar-system::widgets.solarsystem08.orbital_properties.0.labels.y_axis",
             "domain": [[0, 180], null],
             "bins": 9,
             "tooltipAccessors": ["countOfTotal", "inclination"],
@@ -136,24 +136,24 @@
           "label": "solar-system::questions.6.label",
           "options": [
             {
-              "label": "solar-systems::questions.6.options.0.label",
-              "value": "solar-systems::questions.6.options.0.value"
+              "label": "solar-system::questions.6.options.0.label",
+              "value": "solar-system::questions.6.options.0.value"
             },
             {
-              "label": "solar-systems::questions.6.options.1.label",
-              "value": "solar-systems::questions.6.options.1.value"
+              "label": "solar-system::questions.6.options.1.label",
+              "value": "solar-system::questions.6.options.1.value"
             },
             {
-              "label": "solar-systems::questions.6.options.2.label",
-              "value": "solar-systems::questions.6.options.2.value"
+              "label": "solar-system::questions.6.options.2.label",
+              "value": "solar-system::questions.6.options.2.value"
             },
             {
-              "label": "solar-systems::questions.6.options.3.label",
-              "value": "solar-systems::questions.6.options.3.value"
+              "label": "solar-system::questions.6.options.3.label",
+              "value": "solar-system::questions.6.options.3.value"
             }
           ],
           "placeholder": "solar-system::questions.6.placeholder",
-          "answerPre": "<p>Selected: </p>",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]
@@ -164,23 +164,23 @@
           "id": "4",
           "questionType": "select",
           "title": "Question #1",
-          "label": "Eccentricity: ",
+          "label": "solar-system::questions.4.label",
           "options": [
             {
-              "label": "Most orbits are similar to the shape of Earth’s orbit  (0.0 - 0.3)",
-              "value": "Similar to Earth’s (0.0 - 0.3)"
+              "label": "solar-system::questions.4.options.0.label",
+              "value": "solar-system::questions.4.options.0.value"
             },
             {
-              "label": "Most orbits are noticeably more elliptical than the shape of Earth’s orbit (greater than 0.3)",
-              "value": "More elliptical than Earth’s (greater than 0.3)"
+              "label": "solar-system::questions.4.options.1.label",
+              "value": "solar-system::questions.4.options.1.value"
             },
             {
-              "label": "There is an equal distribution across all shapes of orbits",
-              "value": "Wide range of shapes"
+              "label": "solar-system::questions.4.options.2.label",
+              "value": "solar-system::questions.4.options.2.value"
             }
           ],
-          "placeholder": "Select best description of NEOs",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "solar-system::questions.6.placeholder",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]
@@ -191,23 +191,23 @@
           "id": "5",
           "questionType": "select",
           "title": "Question #1",
-          "label": "Inclination: ",
+          "label": "solar-system::questions.5.label",
           "options": [
             {
-              "label": "Most orbits are similar to the tilt of Earth’s orbital plane (0-20°).",
-              "value": "Similar to Earth’s (0-20°)"
+              "label": "solar-system::questions.5.options.0.label",
+              "value": "solar-system::questions.5.options.0.value"
             },
             {
-              "label": "Most orbits are tilted compared to Earth’s orbital plane (more than 20°).",
-              "value": "More tilted than Earth's (more than 20°)"
+              "label": "solar-system::questions.5.options.1.label",
+              "value": "solar-system::questions.5.options.1.value"
             },
             {
-              "label": "There is an equal distribution across all tilts of the orbits.",
-              "value": "Wide range in tilts"
+              "label": "solar-system::questions.5.options.2.label",
+              "value": "solar-system::questions.5.options.2.value"
             }
           ],
-          "placeholder": "Select best description of NEOs",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "solar-system::questions.6.placeholder",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]
@@ -218,19 +218,19 @@
           "id": "7",
           "questionType": "select",
           "title": "Question #1",
-          "label": "Direction of the orbit (remember, an inclination greater than 90° indicates that the object orbits the Sun opposite the direction of Earth’s orbit): ",
+          "label": "solar-system::questions.7.label",
           "options": [
             {
-              "label": "Almost all objects orbit the Sun in the same direction as Earth’s orbit.",
-              "value": "Same direction as Earth’s"
+              "label": "solar-system::questions.7.options.0.label",
+              "value": "solar-system::questions.7.options.0.value"
             },
             {
-              "label": "More than 10% of the objects orbit the Sun in the opposite direction of Earth’s orbit (i >90°).",
-              "value": "Opposite direction as Earth’s (i >90°)"
+              "label": "solar-system::questions.7.options.1.label",
+              "value": "solar-system::questions.7.options.1.value"
             }
           ],
-          "placeholder": "Select best description of NEOs",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "solar-system::questions.6.placeholder",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]

--- a/src/data/pages/characterizing-orbits-4.json
+++ b/src/data/pages/characterizing-orbits-4.json
@@ -3,15 +3,15 @@
   "investigation": "solar-system",
   "sectionOrder": 0,
   "order": "10",
-  "title": "Comparing Orbital Properties",
+  "title": "solar-system::pages.solarsystem12.title",
   "slug": "characterizing-orbits-4/",
   "previous": {
-    "title": "Characterizing Comets",
-    "link": "/characterizing-comet/"
+    "title": "solar-system::pages.solarsystem11.title",
+    "link": "solar-system::pages.solarsystem11.link"
   },
   "next": {
-    "title": "Distributions of Solar System Objects",
-    "link": "/identifying-groups/"
+    "title": "solar-system::pages.solarsystem13.title",
+    "link": "solar-system::pages.solarsystem13.link"
   },
   "layout": "SingleCol",
   "tables": [
@@ -23,13 +23,18 @@
       },
       "fixed": true,
       "colTitles": [
-        "Group",
-        "Size of Orbit",
-        "Eccentricity",
-        "Inclination",
-        "Direction of Orbit"
+        "astronomy::orbital_properties.group",
+        "astronomy::orbital_properties.size_of_orbit",
+        "astronomy::orbital_properties.eccentricity",
+        "astronomy::orbital_properties.inclination",
+        "astronomy::orbital_properties.direction_of_orbit"
       ],
-      "rowTitles": [["NEOs"], ["MBAs"], ["TNOs"], ["Comets"]],
+      "rowTitles": [
+        ["astronomy::orbital_bodies.neo_abbrev_plural"],
+        ["astronomy::orbital_bodies.mba_abbrev_plural"],
+        ["astronomy::orbital_bodies.tno_abbrev_plural"],
+        ["astronomy::orbital_bodies.comet_plural"]
+      ],
       "rows": [
         [
           { "accessor": "data", "id": "6" },
@@ -66,7 +71,7 @@
           "questionType": "textArea",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "What differences exist between the different groups of objects? Provide at least three examples."
+          "label": "solar-system::questions.20.label"
         }
       ]
     },
@@ -77,7 +82,7 @@
           "questionType": "textArea",
           "answerAccessor": "text",
           "title": "Question #2",
-          "label": "Which group of objects will experience the greatest change in orbital speed during one orbital period? Explain your reasoning."
+          "label": "solar-system::questions.20a.label"
         }
       ]
     }

--- a/src/data/pages/characterizing-tno.json
+++ b/src/data/pages/characterizing-tno.json
@@ -3,18 +3,18 @@
   "investigation": "solar-system",
   "sectionOrder": 0,
   "order": "08",
-  "title": "Characterizing Trans-Neptunian Objects (TNOs)",
+  "title": "solar-system::pages.solarsystem10.title",
   "slug": "characterizing-tno/",
   "previous": {
-    "title": "Characterizing Main Belt Asteroids (MBAs)",
-    "link": "/characterizing-mba/"
+    "title": "solar-system::pages.solarsystem09.title",
+    "link": "solar-system::pages.solarsystem09.link"
   },
   "next": {
-    "title": "Characterizing Comets",
-    "link": "/characterizing-comet/"
+    "title": "solar-system::pages.solarsystem11.title",
+    "link": "solar-system::pages.solarsystem11.link"
   },
   "layout": "TwoCol",
-  "content": "<p>TNOs are objects that orbit the Sun at or beyond the orbit of Neptune, at a distance of about 30 au and beyond. This area includes the Kuiper Belt and the entire region out to the inner Oort Cloud, which begins at approximately 2000 au from the Sun.</p><p>Decide which of the statements provided below best describes the orbital properties of TNOs.</p>",
+  "content": "solar-system::content.solarsystem10",
   "tables": [
     {
       "id": "1",
@@ -24,13 +24,18 @@
       },
       "fixed": true,
       "colTitles": [
-        "Group",
-        "Size of Orbit",
-        "Eccentricity",
-        "Inclination",
-        "Direction of Orbit"
+        "astronomy::orbital_properties.group",
+        "astronomy::orbital_properties.size_of_orbit",
+        "astronomy::orbital_properties.eccentricity",
+        "astronomy::orbital_properties.inclination",
+        "astronomy::orbital_properties.direction_of_orbit"
       ],
-      "rowTitles": [["NEOs"], ["MBAs"], ["TNOs"], ["Comets"]],
+      "rowTitles": [
+        ["astronomy::orbital_bodies.neo_abbrev_plural"],
+        ["astronomy::orbital_bodies.mba_abbrev_plural"],
+        ["astronomy::orbital_bodies.tno_abbrev_plural"],
+        ["astronomy::orbital_bodies.comet_plural"]
+      ],
       "rows": [
         [
           { "accessor": "data", "id": "6" },
@@ -68,42 +73,51 @@
           "type": "OrbitalProperties",
           "source": "/data/neos/tno_semimajor_axis_hist.json",
           "options": {
-            "title": "TNO Orbit Sizes",
+            "title": "solar-system::widgets.solarsystem10.orbital_properties.0.title",
             "icon": "barChart",
-            "xAxisLabel": "Orbit Sizes (au)",
+            "xAxisLabel": "astronomy::orbital_properties.size_of_orbit_with_unit",
             "xValueAccessor": "semimajor_axis",
-            "yAxisLabel": "Number of TNOs",
+            "yAxisLabel": "solar-system::widgets.solarsystem10.orbital_properties.0.labels.y_axis",
             "domain": [[0, 65], []],
             "tooltipAccessors": ["countOfTotal", "semimajor_axis"],
-            "tooltipLabels": ["TNOs", "Orbit Size (au)"]
+            "tooltipLabels": [
+              "astronomy::orbital_bodies.tno_abbrev_plural",
+              "astronomy::orbital_properties.size_of_orbit_with_unit"
+            ]
           }
         },
         {
           "type": "OrbitalProperties",
           "source": "/data/neos/tno_eccentricity_hist.json",
           "options": {
-            "title": "TNO Eccentricities",
-            "xAxisLabel": "Eccentricities",
+            "title": "solar-system::widgets.solarsystem10.orbital_properties.1.title",
+            "xAxisLabel": "astronomy::orbital_properties.eccentricity_plural",
             "xValueAccessor": "eccentricity",
-            "yAxisLabel": "Number of TNOs",
+            "yAxisLabel": "solar-system::widgets.solarsystem10.orbital_properties.0.labels.y_axis",
             "domain": [[0, 1], []],
             "bins": 10,
             "tooltipAccessors": ["countOfTotal", "eccentricity"],
-            "tooltipLabels": ["TNOs", "Eccentricity"]
+            "tooltipLabels": [
+              "astronomy::orbital_bodies.tno_abbrev_plural",
+              "astronomy::orbital_properties.eccentricity"
+            ]
           }
         },
         {
           "type": "OrbitalProperties",
           "source": "/data/neos/tno_inclination_hist.json",
           "options": {
-            "title": "TNO Inclinations",
-            "xAxisLabel": "Inclinations (degrees)",
+            "title": "solar-system::widgets.solarsystem10.orbital_properties.1.title",
+            "xAxisLabel": "astronomy::orbital_properties.inclination_unit",
             "xValueAccessor": "inclination",
-            "yAxisLabel": "Number of TNOs",
+            "yAxisLabel": "solar-system::widgets.solarsystem10.orbital_properties.0.labels.y_axis",
             "domain": [[0, 180], []],
             "bins": 9,
             "tooltipAccessors": ["countOfTotal", "inclination"],
-            "tooltipLabels": ["TNOs", "Inclination (degrees)"]
+            "tooltipLabels": [
+              "astronomy::orbital_bodies.tno_abbrev_plural",
+              "astronomy::orbital_properties.inclination_unit"
+            ]
           }
         }
       ],
@@ -117,27 +131,27 @@
           "id": "14",
           "questionType": "select",
           "title": "Question #1",
-          "label": "Size of the orbit: ",
+          "label": "solar-system::questions.6.label",
           "options": [
             {
-              "label": "All of the orbits are within the inner Solar System (between 0.5 - 4 au).",
-              "value": "Within inner Solar System (between 0.5 - 4 au)"
+              "label": "solar-system::questions.6.options.0.label",
+              "value": "solar-system::questions.6.options.0.value"
             },
             {
-              "label": "All of the orbits are within the inner Solar System (between 1.5 - 5.2 au).",
-              "value": "Within inner Solar System (between 1.5 - 5.2 au)"
+              "label": "solar-system::questions.6.options.1.label",
+              "value": "solar-system::questions.6.options.1.value"
             },
             {
-              "label": "The orbit sizes are 30 au or larger, and objects typically orbit beyond Neptune.",
-              "value": "In the outer Solar System (30 au or larger)"
+              "label": "solar-system::questions.6.options.2.label",
+              "value": "solar-system::questions.6.options.2.value"
             },
             {
-              "label": "The orbit sizes span both the inner and outer Solar System, beyond 30 au.",
-              "value": "Span inner and outer Solar System (beyond 30 au)"
+              "label": "solar-system::questions.6.options.3.label",
+              "value": "solar-system::questions.6.options.3.value"
             }
           ],
-          "placeholder": "Select best description of TNOs",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "solar-system::questions.12.placeholder",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]
@@ -148,23 +162,23 @@
           "id": "12",
           "questionType": "select",
           "title": "Question #1",
-          "label": "Eccentricity: ",
+          "label": "solar-system::questions.4.label",
           "options": [
             {
-              "label": "Most orbits are similar to the shape of Earth’s orbit  (0.0 - 0.3)",
-              "value": "Similar to Earth’s (0.0 - 0.3)"
+              "label": "solar-system::questions.4.options.0.label",
+              "value": "solar-system::questions.4.options.0.value"
             },
             {
-              "label": "Most orbits are noticeably more elliptical than the shape of Earth’s orbit (greater than 0.3)",
-              "value": "More elliptical than Earth’s (greater than 0.3)"
+              "label": "solar-system::questions.4.options.1.label",
+              "value": "solar-system::questions.4.options.1.value"
             },
             {
-              "label": "There is an equal distribution across all shapes of orbits",
-              "value": "Wide range of shapes"
+              "label": "solar-system::questions.4.options.2.label",
+              "value": "solar-system::questions.4.options.2.value"
             }
           ],
-          "placeholder": "Select best description of TNOs",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "solar-system::questions.12.placeholder",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]
@@ -175,23 +189,23 @@
           "id": "13",
           "questionType": "select",
           "title": "Question #1",
-          "label": "Inclination: ",
+          "label": "solar-system::questions.5.label",
           "options": [
             {
-              "label": "Most orbits are similar to the tilt of Earth’s orbital plane (0-20°).",
-              "value": "Similar to Earth’s (0-20°)"
+              "label": "solar-system::questions.5.options.0.label",
+              "value": "solar-system::questions.5.options.0.value"
             },
             {
-              "label": "Most orbits are tilted compared to Earth’s orbital plane (more than 20°).",
-              "value": "More tilted than Earth's (more than 20°)"
+              "label": "solar-system::questions.5.options.1.label",
+              "value": "solar-system::questions.5.options.1.value"
             },
             {
-              "label": "There is an equal distribution across all tilts of the orbits.",
-              "value": "Wide range in tilts"
+              "label": "solar-system::questions.5.options.2.label",
+              "value": "solar-system::questions.5.options.2.value"
             }
           ],
-          "placeholder": "Select best description of TNOs",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "solar-system::questions.12.placeholder",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]
@@ -202,19 +216,19 @@
           "id": "15",
           "questionType": "select",
           "title": "Question #1",
-          "label": "Direction of the orbit (remember, an inclination greater than 90° indicates that the object orbits the Sun opposite the direction of Earth’s orbit): ",
+          "label": "solar-system::questions.7.label",
           "options": [
             {
-              "label": "Almost all objects orbit the Sun in the same direction as Earth’s orbit.",
-              "value": "Same direction as Earth’s"
+              "label": "solar-system::questions.7.options.0.label",
+              "value": "solar-system::questions.7.options.0.value"
             },
             {
-              "label": "More than 10% of the objects orbit the Sun in the opposite direction of Earth’s orbit (i >90°).",
-              "value": "Opposite direction as Earth’s (i >90°)"
+              "label": "solar-system::questions.7.options.1.label",
+              "value": "solar-system::questions.7.options.1.value"
             }
           ],
-          "placeholder": "Select best description of TNOs",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "solar-system::questions.12.placeholder",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]

--- a/src/data/pages/classifying-objects-1.json
+++ b/src/data/pages/classifying-objects-1.json
@@ -3,18 +3,18 @@
   "investigation": "solar-system",
   "sectionOrder": 2,
   "order": "23",
-  "title": "Classifying Newly Detected Solar System Objects - 2",
+  "title": "solar-system::pages.solarsystem23.title",
   "slug": "classifying-objects-1/",
   "previous": {
-    "title": "Classifying Newly Detected Solar System Objects - 1",
-    "link": "/classifying-objects/"
+    "title": "solar-system::pages.solarsystem22.title",
+    "link": "solar-system::pages.solarsystem22.link"
   },
   "next": {
-    "title": "Classifying Newly Detected Solar System Objects - 3",
-    "link": "/classifying-objects-2/"
+    "title": "solar-system::pages.solarsystem24.title",
+    "link": "solar-system::pages.solarsystem24.link"
   },
   "layout": "TwoCol",
-  "content": "Use the orbital properties in the table you constructed above to help you determine which group this newly discovered object belongs to.",
+  "content": "solar-system::content.solarsystem23",
   "widgets": [
     {
       "type": "OrbitalViewer",
@@ -36,13 +36,18 @@
       },
       "fixed": true,
       "colTitles": [
-        "Group",
-        "Size of Orbit",
-        "Eccentricity",
-        "Inclination",
-        "Direction of Orbit"
+        "astronomy::orbital_properties.group",
+        "astronomy::orbital_properties.size_of_orbit",
+        "astronomy::orbital_properties.eccentricity",
+        "astronomy::orbital_properties.inclination",
+        "astronomy::orbital_properties.direction_of_orbit"
       ],
-      "rowTitles": [["NEOs"], ["MBAs"], ["TNOs"], ["Comets"]],
+      "rowTitles": [
+        ["astronomy::orbital_bodies.neo_abbrev_plural"],
+        ["astronomy::orbital_bodies.mba_abbrev_plural"],
+        ["astronomy::orbital_bodies.tno_abbrev_plural"],
+        ["astronomy::orbital_bodies.comet_plural"]
+      ],
       "rows": [
         [
           { "accessor": "data", "id": "6" },
@@ -77,7 +82,12 @@
         "row": "bottom",
         "col": "left"
       },
-      "colTitles": ["", "Name", "Type", "Data/Evidence"],
+      "colTitles": [
+        "",
+        "solar-system::tables.2.colTitles.0",
+        "solar-system::tables.2.colTitles.1",
+        "solar-system::tables.2.colTitles.2"
+      ],
       "rowTitles": [["#1"], ["#2"], ["#3"]],
       "rows": [
         [
@@ -107,7 +117,7 @@
           "questionType": "text",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "What is this object's name?"
+          "label": "solar-system::questions.46.label"
         }
       ]
     },
@@ -117,31 +127,31 @@
           "id": "50",
           "questionType": "select",
           "title": "Question #1",
-          "label": "What type of object is this?",
+          "label": "solar-system::questions.47.label",
           "options": [
             {
-              "label": "MBA",
-              "value": "MBA"
+              "label": "astronomy::orbital_bodies.mba_abbrev",
+              "value": "astronomy::orbital_bodies.mba_abbrev"
             },
             {
-              "label": "TNO",
-              "value": "TNO"
+              "label": "astronomy::orbital_bodies.tno_abbrev",
+              "value": "astronomy::orbital_bodies.tno_abbrev"
             },
             {
-              "label": "NEO",
-              "value": "NEO"
+              "label": "astronomy::orbital_bodies.neo_abbrev",
+              "value": "astronomy::orbital_bodies.neo_abbrev"
             },
             {
-              "label": "Comet",
-              "value": "Comet"
+              "label": "astronomy::orbital_bodies.comet",
+              "value": "astronomy::orbital_bodies.comet"
             },
             {
-              "label": "None of the above",
-              "value": "None of the above"
+              "label": "interface::qas.options.none_of_the_above",
+              "value": "interface::qas.options.none_of_the_above"
             }
           ],
-          "placeholder": "Select",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "interface::actions.select",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]
@@ -153,7 +163,7 @@
           "questionType": "textArea",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "Explain why you chose this type.  What data/evidence supports your choice?"
+          "label": "solar-system::questions.48.label"
         }
       ]
     }

--- a/src/data/pages/classifying-objects-2.json
+++ b/src/data/pages/classifying-objects-2.json
@@ -3,18 +3,18 @@
   "investigation": "solar-system",
   "sectionOrder": 2,
   "order": "24",
-  "title": "Classifying Newly Detected Solar System Objects - 3",
+  "title": "solar-system::pages.solarsystem24.title",
   "slug": "classifying-objects-2/",
   "previous": {
-    "title": "Classifying Newly Detected Solar System Objects - 2",
-    "link": "/classifying-objects-1/"
+    "title": "solar-system::pages.solarsystem23.title",
+    "link": "solar-system::pages.solarsystem23.link"
   },
   "next": {
-    "title": "Exploring A New Class of Objects",
-    "link": "/solar-system-summary/"
+    "title": "solar-system::pages.solarsystem28.title",
+    "link": "solar-system::pages.solarsystem28.link"
   },
   "layout": "TwoCol",
-  "content": "<p>Use the orbital properties in the table you constructed above to help you determine which group this newly discovered object belongs to.</p>",
+  "content": "solar-system::content.solarsystem23",
   "widgets": [
     {
       "type": "OrbitalViewer",
@@ -36,13 +36,18 @@
       },
       "fixed": true,
       "colTitles": [
-        "Group",
-        "Size of Orbit",
-        "Eccentricity",
-        "Inclination",
-        "Direction of Orbit"
+        "astronomy::orbital_properties.group",
+        "astronomy::orbital_properties.size_of_orbit",
+        "astronomy::orbital_properties.eccentricity",
+        "astronomy::orbital_properties.inclination",
+        "astronomy::orbital_properties.direction_of_orbit"
       ],
-      "rowTitles": [["NEOs"], ["MBAs"], ["TNOs"], ["Comets"]],
+      "rowTitles": [
+        ["astronomy::orbital_bodies.neo_abbrev_plural"],
+        ["astronomy::orbital_bodies.mba_abbrev_plural"],
+        ["astronomy::orbital_bodies.tno_abbrev_plural"],
+        ["astronomy::orbital_bodies.comet_plural"]
+      ],
       "rows": [
         [
           { "accessor": "data", "id": "6" },
@@ -77,7 +82,12 @@
         "row": "bottom",
         "col": "left"
       },
-      "colTitles": ["", "Name", "Type", "Data/Evidence"],
+      "colTitles": [
+        "",
+        "solar-system::tables.2.colTitles.0",
+        "solar-system::tables.2.colTitles.1",
+        "solar-system::tables.2.colTitles.2"
+      ],
       "rowTitles": [["#1"], ["#2"], ["#3"]],
       "rows": [
         [
@@ -106,7 +116,7 @@
           "questionType": "text",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "What is this object's name?"
+          "label": "solar-system::questions.46.label"
         }
       ]
     },
@@ -116,31 +126,31 @@
           "id": "67",
           "questionType": "select",
           "title": "Question #1",
-          "label": "What type of object is this?",
+          "label": "solar-system::questions.47.label",
           "options": [
             {
-              "label": "MBA",
-              "value": "MBA"
+              "label": "astronomy::orbital_bodies.mba_abbrev",
+              "value": "astronomy::orbital_bodies.mba_abbrev"
             },
             {
-              "label": "TNO",
-              "value": "TNO"
+              "label": "astronomy::orbital_bodies.tno_abbrev",
+              "value": "astronomy::orbital_bodies.tno_abbrev"
             },
             {
-              "label": "NEO",
-              "value": "NEO"
+              "label": "astronomy::orbital_bodies.neo_abbrev",
+              "value": "astronomy::orbital_bodies.neo_abbrev"
             },
             {
-              "label": "Comet",
-              "value": "Comet"
+              "label": "astronomy::orbital_bodies.comet",
+              "value": "astronomy::orbital_bodies.comet"
             },
             {
-              "label": "None of the above",
-              "value": "None of the above"
+              "label": "interface::qas.options.none_of_the_above",
+              "value": "interface::qas.options.none_of_the_above"
             }
           ],
-          "placeholder": "Select",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "interface::actions.select",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]
@@ -152,7 +162,7 @@
           "questionType": "textArea",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "Explain why you chose this type.  What data/evidence supports your choice?"
+          "label": "solar-system::questions.48.label"
         }
       ]
     }

--- a/src/data/pages/classifying-objects.json
+++ b/src/data/pages/classifying-objects.json
@@ -3,18 +3,18 @@
   "investigation": "solar-system",
   "sectionOrder": 2,
   "order": "22",
-  "title": "Classifying Newly Detected Solar System Objects - 1",
+  "title": "solar-system::pages.solarsystem22.title",
   "slug": "classifying-objects/",
   "previous": {
-    "title": "Progress Update",
-    "link": "/section-2/"
+    "title": "solar-system::pages.solar-system-2-break.title",
+    "link": "solar-system::pages.solar-system-2-break.link"
   },
   "next": {
-    "title": "Classifying Newly Detected Solar System Objects - 2",
-    "link": "/classifying-objects-1/"
+    "title": "solar-system::pages.solarsystem23.title",
+    "link": "solar-system::pages.solarsystem23.link"
   },
   "layout": "TwoCol",
-  "content": "<p>Many small Solar System objects have been recently discovered by Rubin Observatory. You now have the chance to apply what you have learned to classify three such objects. Your choices for classifying each object are:<ul><li>MBA</li><li>TNO</li><li>NEO</li><li>Comet</li><li>None of the above</li></ul></p>Use the orbital properties in the table you constructed above to help you determine which group this newly discovered object belongs to.",
+  "content": "solar-system::content.solarsystem22",
   "widgets": [
     {
       "type": "OrbitalViewer",
@@ -36,13 +36,18 @@
       },
       "fixed": true,
       "colTitles": [
-        "Group",
-        "Size of Orbit",
-        "Eccentricity",
-        "Inclination",
-        "Direction of Orbit"
+        "astronomy::orbital_properties.group",
+        "astronomy::orbital_properties.size_of_orbit",
+        "astronomy::orbital_properties.eccentricity",
+        "astronomy::orbital_properties.inclination",
+        "astronomy::orbital_properties.direction_of_orbit"
       ],
-      "rowTitles": [["NEOs"], ["MBAs"], ["TNOs"], ["Comets"]],
+      "rowTitles": [
+        ["astronomy::orbital_bodies.neo_abbrev_plural"],
+        ["astronomy::orbital_bodies.mba_abbrev_plural"],
+        ["astronomy::orbital_bodies.tno_abbrev_plural"],
+        ["astronomy::orbital_bodies.comet_plural"]
+      ],
       "rows": [
         [
           { "accessor": "data", "id": "6" },
@@ -77,7 +82,12 @@
         "row": "bottom",
         "col": "left"
       },
-      "colTitles": ["", "Name", "Type", "Data/Evidence"],
+      "colTitles": [
+        "",
+        "solar-system::tables.2.colTitles.0",
+        "solar-system::tables.2.colTitles.1",
+        "solar-system::tables.2.colTitles.2"
+      ],
       "rowTitles": [["#1"], ["#2"], ["#3"]],
       "rows": [
         [
@@ -107,7 +117,7 @@
           "questionType": "text",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "What is this object's name?"
+          "label": "solar-system::questions.46.label"
         }
       ]
     },
@@ -117,31 +127,31 @@
           "id": "47",
           "questionType": "select",
           "title": "Question #1",
-          "label": "What type of object is this?",
+          "label": "solar-system::questions.47.label",
           "options": [
             {
-              "label": "MBA",
-              "value": "MBA"
+              "label": "astronomy::orbital_bodies.mba_abbrev",
+              "value": "astronomy::orbital_bodies.mba_abbrev"
             },
             {
-              "label": "TNO",
-              "value": "TNO"
+              "label": "astronomy::orbital_bodies.tno_abbrev",
+              "value": "astronomy::orbital_bodies.tno_abbrev"
             },
             {
-              "label": "NEO",
-              "value": "NEO"
+              "label": "astronomy::orbital_bodies.neo_abbrev",
+              "value": "astronomy::orbital_bodies.neo_abbrev"
             },
             {
-              "label": "Comet",
-              "value": "Comet"
+              "label": "astronomy::orbital_bodies.comet",
+              "value": "astronomy::orbital_bodies.comet"
             },
             {
-              "label": "None of the above",
-              "value": "None of the above"
+              "label": "interface::qas.options.none_of_the_above",
+              "value": "interface::qas.options.none_of_the_above"
             }
           ],
-          "placeholder": "Select",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "interface::actions.select",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]
@@ -153,7 +163,7 @@
           "questionType": "textArea",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "Explain why you chose this type.  What data/evidence supports your choice?"
+          "label": "solar-system::questions.48.label"
         }
       ]
     }

--- a/src/data/pages/detecting-objects.json
+++ b/src/data/pages/detecting-objects.json
@@ -20,7 +20,7 @@
         "col": "left",
         "row": "top"
       },
-      "content": "<p>Each night, the Rubin Observatory LSST camera takes two images of the same star field, at least thirty minutes apart. The images are compared by computer software, and if anything has moved an <a href='http://rubineducation.org/glossary/alert' target='_blank'>alert</a> is automatically generated, and the data sent to the <a target='_blank' href='https://www.minorplanetcenter.net/about'>IAU Minor Planet Center</a> (MPC). Within hours, the MPC determines a preliminary orbit for the object.</p><p>Here are some sample observations of moving Solar System objects. Observe how each object moves through the star field. Both images cover the same area of the sky (same field of view).</p>"
+      "content": "solar-system::content.solarsystem02"
     }
   ],
   "widgets": [
@@ -47,8 +47,14 @@
           "title": "Question #1",
           "label": "solar-system::questions.1.label",
           "options": [
-            { "label": "interface::qas.options.yes", "value": "yes" },
-            { "label": "interface::qas.options.no", "value": "no" }
+            {
+              "label": "interface::qas.options.yes",
+              "value": "interface::qas.options.yes"
+            },
+            {
+              "label": "interface::qas.options.no",
+              "value": "interface::qas.options.no"
+            }
           ],
           "placeholder": "interface::actions.select",
           "answerPre": "interface::qas.answer_pre",
@@ -68,8 +74,14 @@
           "answerAccessor": "select",
           "placeholder": "interface::actions.select",
           "options": [
-            { "label": "interface::qas.options.closer", "value": "closer" },
-            { "label": "interface::qas.options.farther", "value": "farther" }
+            {
+              "label": "interface::qas.options.closer",
+              "value": "interface::qas.options.closer"
+            },
+            {
+              "label": "interface::qas.options.farther",
+              "value": "interface::qas.options.farther"
+            }
           ],
           "answerPre": "...",
           "answerPost": "..."
@@ -82,10 +94,16 @@
           "labelPost": " orbital period.",
           "srLabel": "...",
           "answerAccessor": "select",
-          "placeholder": "Select a type",
+          "placeholder": "interface::actions.select_type",
           "options": [
-            { "label": "interface::qas.options.long", "value": "long" },
-            { "label": "interface::qas.options.short", "value": "short" }
+            {
+              "label": "interface::qas.options.long",
+              "value": "interface::qas.options.long"
+            },
+            {
+              "label": "interface::qas.options.short",
+              "value": "interface::qas.options.short"
+            }
           ],
           "answerPre": "...",
           "answerPost": "..."

--- a/src/data/pages/eccentricity.json
+++ b/src/data/pages/eccentricity.json
@@ -3,23 +3,23 @@
   "investigation": "solar-system",
   "sectionOrder": 0,
   "order": "03",
-  "title": "Eccentricity",
+  "title": "solar-system::pages.solarsystem05.title",
   "slug": "eccentricity/",
   "previous": {
-    "title": "Semi-Major Axis",
-    "link": "/semi-major-axis/"
+    "title": "solar-system::pages.solarsystem04.title",
+    "link": "solar-system::pages.solarsystem04.link"
   },
   "next": {
-    "title": "Inclination",
-    "link": "/inclination/"
+    "title": "solar-system::pages.solarsystem06.title",
+    "link": "solar-system::pages.solarsystem06.link"
   },
   "layout": "TwoCol",
-  "content": "<p><a href='http://rubineducation.org/glossary/eccentricity' target='_blank'>Eccentricity</a> describes how elliptical (i.e., oval shaped) an orbit is. Eccentricity values range from 0 to almost 1. An eccentricity of 0 describes a perfectly circular orbit. The larger the eccentricity, the more elliptical the orbit.</p>",
+  "content": "solar-system::content.solarsystem05",
   "images": [
     {
       "mediaPath": "/images/20220203 Orbital characteristics.gif",
-      "altText": "Examples of orbital ellipses with different eccentricities.",
-      "figText": "Examples of orbital ellipses with different eccentricities. Credit: Rubin Observatory"
+      "altText": "solar-system::images.solarsystem05.altText",
+      "figText": "solar-system::images.solarsystem05.figText"
     }
   ]
 }

--- a/src/data/pages/history-solar-system-1.json
+++ b/src/data/pages/history-solar-system-1.json
@@ -3,30 +3,33 @@
   "investigation": "solar-system",
   "sectionOrder": 1,
   "order": "05",
-  "title": "Supporting Evidence for Solar System Formation",
+  "title": "solar-system::pages.solarsystem19.title",
   "slug": "history-solar-system-1/",
   "previous": {
-    "title": "The Formation of the Solar System",
-    "link": "/history-solar-system/"
+    "title": "solar-system::pages.solarsystem18.title",
+    "link": "solar-system::pages.solarsystem18.link"
   },
   "next": {
-    "title": "Gravitational Interactions in the Solar System",
-    "link": "/nebula-theory/"
+    "title": "solar-system::pages.solarsystem19a.title",
+    "link": "solar-system::pages.solarsystem19a.link"
   },
   "layout": "TwoCol",
-  "content": "<p>We can also find evidence to support the solar nebula theory by studying the motions of objects within the Solar System. To validate this evidence, view a histogram that shows inclinations of all four groups of Solar System objects and look for overall patterns in the way objects orbit the Sun. (Remember, any inclination greater than 90 degrees indicates an object that is orbiting backwards.)</p>",
+  "content": "solar-system::content.solarsystem19",
   "widgets": [
     {
       "type": "OrbitalProperties",
       "source": "/data/neos/all_inclination_hist.json",
       "options": {
-        "title": "Inclinations",
-        "xAxisLabel": "Inclinations (degrees)",
+        "title": "astronomy::orbital_properties.inclination_plural",
+        "xAxisLabel": "astronomy::orbital_properties.inclination_unit",
         "xValueAccessor": "inclination",
-        "yAxisLabel": "Number of Objects",
+        "yAxisLabel": "solar-system::widgets.solarsystem19.orbital_properties.labels.y_axis",
         "domain": [[0, 180], null],
         "tooltipAccessors": ["countOfTotal", "inclination"],
-        "tooltipLabels": ["Objects", "Inclination (degrees)"],
+        "tooltipLabels": [
+          "solar-system::widgets.solarsystem19.orbital_properties.labels.tooltip",
+          "astronomy::orbital_properties.inclination_unit_plural"
+        ],
         "qaReview": false
       }
     }
@@ -39,14 +42,23 @@
           "questionType": "select",
           "title": "Question #1",
           "labelPre": "",
-          "labelPost": "of the small Solar System objects have orbits that lie in the orbital plane of the planets.",
+          "labelPost": "solar-system::questions.32.labelPost",
           "options": [
-            { "label": "Almost none", "value": "None" },
-            { "label": "Nearly all", "value": "Nearly all" },
-            { "label": "Roughly half", "value": "Roughly half" }
+            {
+              "label": "interface::qas.options.almost_none",
+              "value": "interface::qas.options.almost_none"
+            },
+            {
+              "label": "interface::qas.options.nearly_all",
+              "value": "interface::qas.options.nearly_all"
+            },
+            {
+              "label": "interface::qas.options.roughly_half",
+              "value": "interface::qas.options.roughly_half"
+            }
           ],
-          "placeholder": "Select",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "interface::actions.select",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]
@@ -58,14 +70,23 @@
           "questionType": "select",
           "title": "Question #1",
           "labelPre": "",
-          "labelPost": "of the Solar System objects orbit in the opposite direction of the planets around the Sun.",
+          "labelPost": "solar-system::questions.32a.labelPost",
           "options": [
-            { "label": "Almost none", "value": "None" },
-            { "label": "Nearly all", "value": "Nearly all" },
-            { "label": "Roughly half", "value": "Roughly half" }
+            {
+              "label": "interface::qas.options.almost_none",
+              "value": "interface::qas.options.almost_none"
+            },
+            {
+              "label": "interface::qas.options.nearly_all",
+              "value": "interface::qas.options.nearly_all"
+            },
+            {
+              "label": "interface::qas.options.roughly_half",
+              "value": "interface::qas.options.roughly_half"
+            }
           ],
-          "placeholder": "Select",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "interface::actions.select",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]
@@ -77,7 +98,7 @@
           "questionType": "textArea",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "How do the range of values for the inclination for the small objects of the Solar System support the nebular theory?"
+          "label": "solar-system::questions.33.label"
         }
       ]
     }

--- a/src/data/pages/history-solar-system.json
+++ b/src/data/pages/history-solar-system.json
@@ -3,32 +3,32 @@
   "investigation": "solar-system",
   "sectionOrder": 1,
   "order": "04",
-  "title": "The Formation of the Solar System",
+  "title": "solar-system::pages.solarsystem18.title",
   "slug": "history-solar-system/",
   "previous": {
-    "title": "Identifying Groups of Solar System Objects - 4",
-    "link": "/identifying-groups-4/"
+    "title": "solar-system::pages.solarsystem17.title",
+    "link": "solar-system::pages.solarsystem17.link"
   },
   "next": {
-    "title": "Supporting Evidence for Solar System Formation",
-    "link": "/history-solar-system-1/"
+    "title": "solar-system::pages.solarsystem19.title",
+    "link": "solar-system::pages.solarsystem19.link"
   },
   "layout": "TwoCol",
   "contents": [
     {
       "layout": { "col": "left", "row": "top" },
-      "content": "<p>According to the solar nebula theory, a spinning cloud of dust and gas collapsed due to gravity and the young Sun began to form at the center, while dusty and icy objects began to grow by repeated collisions with each other in a flattened disk surrounding the Sun. The Sun, planets, and the disk surrounding it retained the same direction of motion as the spinning cloud that formed the Sun.</p><p>There is significant evidence to support this theory. Observations of star-forming regions reveal similar disks around young stars in other parts of the galaxy. Another piece of evidence that supports the theory is the fact that rocky planets formed close to the Sun (where temperatures were hotter) and icy planets formed at greater distances (where temperatures were much cooler).</p>"
+      "content": "solar-system::content.solarsystem18.0"
     },
     {
       "layout": { "col": "right", "row": "top" },
-      "content": "<p>The <a href='http://rubineducation.org/glossary/oort-cloud' target='_blank'>Oort Cloud</a> is a spherical region of icy objects that exists at the outermost edges of the Solar System (extending from a distance of 1000 - 100,000 au), thought to have formed after the collapse of the solar nebula. One idea suggests that gravitational interactions between large planets and small Solar System objects in the early years of the Solar System slung small objects outwards to form the Oort Cloud. Another idea suggests the Sun’s gravity could have plucked some objects from other nearby solar systems.</p>"
+      "content": "solar-system::content.solarsystem18.1"
     }
   ],
   "images": [
     {
       "mediaPath": "/images/stsci-prc15-06a.png",
-      "altText": "Hubble Space Telescope image shows a large, edge-on, gas-and-dust disk encircling the star Beta Pictoris. The light of the central star has been blocked out.",
-      "figText": "This Hubble Space Telescope image shows a large, edge-on, gas-and-dust disk encircling the star Beta Pictoris. The light of the central star has been blocked out. Credits: NASA, ESA, University of Arizona.",
+      "altText": "solar-system::images.solarsystem18.0.altText",
+      "figText": "solar-system::images.solarsystem18.0.figText",
       "layout": {
         "col": "left",
         "row": "top"
@@ -36,8 +36,8 @@
     },
     {
       "mediaPath": "/images/Oort Cloud and Kuiper Belt.jpg",
-      "altText": "Illustration of the Solar System, the Kuiper Belt, and the Oort Cloud. This illustration is not to scale.",
-      "figText": "The Oort Cloud is a spherical shell of icy objects occupying the outermost regions the Solar System. (Drawing not to scale.) Credit: Rubin Observatory",
+      "altText": "solar-system::images.solarsystem18.1.altText",
+      "figText": "solar-system::images.solarsystem18.1.figText",
       "layout": {
         "col": "right",
         "row": "top"
@@ -52,7 +52,7 @@
           "questionType": "textArea",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "Many comets are thought to originate from the Oort Cloud. Explain why these comets might have very inclined orbits compared to other types of Solar System objects."
+          "label": "solar-system::questions.31.label"
         }
       ],
       "layout": {

--- a/src/data/pages/identifying-groups-1.json
+++ b/src/data/pages/identifying-groups-1.json
@@ -3,18 +3,18 @@
   "investigation": "solar-system",
   "sectionOrder": 1,
   "order": "00",
-  "title": "Identifying Groups of Solar System Objects - 1",
+  "title": "solar-system::pages.solarsystem14.title",
   "slug": "identifying-groups-1/",
   "previous": {
-    "title": "Progress Update",
-    "link": "/section-1/"
+    "title": "solar-system::pages.solar-system-1-break.title",
+    "link": "solar-system::pages.solar-system-1-break.link"
   },
   "next": {
-    "title": "Identifying Groups of Solar System Objects - 2",
-    "link": "/identifying-groups-2/"
+    "title": "solar-system::pages.solarsystem15.title",
+    "link": "solar-system::pages.solarsystem15.link"
   },
   "layout": "TwoCol",
-  "content": "<p>Use the Orbit Viewer to explore the orbital characteristics of a representative set of objects from one of the four groups. All of the displayed points and their motions represent real objects. Click and drag to change the angle at which you view the orbits. You can also zoom in and out. Use the buttons in the bottom of the Orbit Viewer to play, pause, or skip forward or backward. Click the reset zoom and orientation button to return to the original view of these objects. You can change time  for the displayed motion by moving the bead on the Time Step scale located at the right of the Orbit Viewer (to a maximum of 1year/second).</p>",
+  "content": "solar-system::content.solarsystem14",
   "widgets": [
     {
       "type": "OrbitalViewer",
@@ -35,13 +35,18 @@
       },
       "fixed": true,
       "colTitles": [
-        "Group",
-        "Size of Orbit",
-        "Eccentricity",
-        "Inclination",
-        "Direction of Orbit"
+        "astronomy::orbital_properties.group",
+        "astronomy::orbital_properties.size_of_orbit",
+        "astronomy::orbital_properties.eccentricity",
+        "astronomy::orbital_properties.inclination",
+        "astronomy::orbital_properties.direction_of_orbit"
       ],
-      "rowTitles": [["NEOs"], ["MBAs"], ["TNOs"], ["Comets"]],
+      "rowTitles": [
+        ["astronomy::orbital_bodies.neo_abbrev_plural"],
+        ["astronomy::orbital_bodies.mba_abbrev_plural"],
+        ["astronomy::orbital_bodies.tno_abbrev_plural"],
+        ["astronomy::orbital_bodies.comet_plural"]
+      ],
       "rows": [
         [
           { "accessor": "data", "id": "6" },

--- a/src/data/pages/identifying-groups-2.json
+++ b/src/data/pages/identifying-groups-2.json
@@ -3,18 +3,18 @@
   "investigation": "solar-system",
   "sectionOrder": 1,
   "order": "01",
-  "title": "Identifying Groups of Solar System Objects - 2",
+  "title": "solar-system::pages.solarsystem15.title",
   "slug": "identifying-groups-2/",
   "previous": {
-    "title": "Identifying Groups of Solar System Objects - 1",
-    "link": "/identifying-groups-1/"
+    "title": "solar-system::pages.solarsystem14.title",
+    "link": "solar-system::pages.solarsystem14.link"
   },
   "next": {
-    "title": "Identifying Groups of Solar System Objects - 3",
-    "link": "/identifying-groups-3/"
+    "title": "solar-system::pages.solarsystem16.title",
+    "link": "solar-system::pages.solarsystem16.link"
   },
   "layout": "TwoCol",
-  "content": "<p>Use the Orbit Viewer to explore this group.</p>",
+  "content": "solar-system::content.solarsystem15",
   "widgets": [
     {
       "type": "OrbitalViewer",
@@ -35,13 +35,18 @@
       },
       "fixed": true,
       "colTitles": [
-        "Group",
-        "Size of Orbit",
-        "Eccentricity",
-        "Inclination",
-        "Direction of Orbit"
+        "astronomy::orbital_properties.group",
+        "astronomy::orbital_properties.size_of_orbit",
+        "astronomy::orbital_properties.eccentricity",
+        "astronomy::orbital_properties.inclination",
+        "astronomy::orbital_properties.direction_of_orbit"
       ],
-      "rowTitles": [["NEOs"], ["MBAs"], ["TNOs"], ["Comets"]],
+      "rowTitles": [
+        ["astronomy::orbital_bodies.neo_abbrev_plural"],
+        ["astronomy::orbital_bodies.mba_abbrev_plural"],
+        ["astronomy::orbital_bodies.tno_abbrev_plural"],
+        ["astronomy::orbital_bodies.comet_plural"]
+      ],
       "rows": [
         [
           { "accessor": "data", "id": "6" },
@@ -79,7 +84,7 @@
           "questionType": "textArea",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "Refer to your table of observations from the previous section.  Which of the four groups do you think this is? Explain your reasoning in terms of the unique set of orbital properties that defines this group of objects."
+          "label": "solar-system::questions.22.label"
         }
       ]
     }

--- a/src/data/pages/identifying-groups-3.json
+++ b/src/data/pages/identifying-groups-3.json
@@ -3,18 +3,18 @@
   "investigation": "solar-system",
   "sectionOrder": 1,
   "order": "02",
-  "title": "Identifying Groups of Solar System Objects - 3",
+  "title": "solar-system::pages.solarsystem16.title",
   "slug": "identifying-groups-3/",
   "previous": {
-    "title": "Identifying Groups of Solar System Objects - 2",
-    "link": "/identifying-groups-2/"
+    "title": "solar-system::pages.solarsystem15.title",
+    "link": "solar-system::pages.solarsystem15.link"
   },
   "next": {
-    "title": "Identifying Groups of Solar System Objects - 4",
-    "link": "/identifying-groups-4/"
+    "title": "solar-system::pages.solarsystem17.title",
+    "link": "solar-system::pages.solarsystem17.link"
   },
   "layout": "TwoCol",
-  "content": "<p>Use the Orbit Viewer to explore this group.</p>",
+  "content": "solar-system::content.solarsystem15",
   "widgets": [
     {
       "type": "OrbitalViewer",
@@ -35,13 +35,18 @@
       },
       "fixed": true,
       "colTitles": [
-        "Group",
-        "Size of Orbit",
-        "Eccentricity",
-        "Inclination",
-        "Direction of Orbit"
+        "astronomy::orbital_properties.group",
+        "astronomy::orbital_properties.size_of_orbit",
+        "astronomy::orbital_properties.eccentricity",
+        "astronomy::orbital_properties.inclination",
+        "astronomy::orbital_properties.direction_of_orbit"
       ],
-      "rowTitles": [["NEOs"], ["MBAs"], ["TNOs"], ["Comets"]],
+      "rowTitles": [
+        ["astronomy::orbital_bodies.neo_abbrev_plural"],
+        ["astronomy::orbital_bodies.mba_abbrev_plural"],
+        ["astronomy::orbital_bodies.tno_abbrev_plural"],
+        ["astronomy::orbital_bodies.comet_plural"]
+      ],
       "rows": [
         [
           { "accessor": "data", "id": "6" },
@@ -79,7 +84,7 @@
           "questionType": "textArea",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "Refer to your table of observations from the previous section.  Which of the four groups do you think this is? Explain your reasoning in terms of the unique set of orbital properties that defines this group of objects."
+          "label": "solar-system::questions.22.label"
         }
       ]
     }

--- a/src/data/pages/identifying-groups-4.json
+++ b/src/data/pages/identifying-groups-4.json
@@ -3,18 +3,18 @@
   "investigation": "solar-system",
   "sectionOrder": 1,
   "order": "03",
-  "title": "Identifying Groups of Solar System Objects - 4",
+  "title": "solar-system::pages.solarsystem17.title",
   "slug": "identifying-groups-4/",
   "previous": {
-    "title": "Identifying Groups of Solar System Objects - 3",
-    "link": "/identifying-groups-3/"
+    "title": "solar-system::pages.solarsystem16.title",
+    "link": "solar-system::pages.solarsystem16.link"
   },
   "next": {
-    "title": "The Formation of the Solar System",
-    "link": "/history-solar-system/"
+    "title": "solar-system::pages.solarsystem18.title",
+    "link": "solar-system::pages.solarsystem18.link"
   },
   "layout": "TwoCol",
-  "content": "<p>Use the Orbit Viewer to explore this group.</p>",
+  "content": "solar-system::content.solarsystem15",
   "widgets": [
     {
       "type": "OrbitalViewer",
@@ -35,13 +35,18 @@
       },
       "fixed": true,
       "colTitles": [
-        "Group",
-        "Size of Orbit",
-        "Eccentricity",
-        "Inclination",
-        "Direction of Orbit"
+        "astronomy::orbital_properties.group",
+        "astronomy::orbital_properties.size_of_orbit",
+        "astronomy::orbital_properties.eccentricity",
+        "astronomy::orbital_properties.inclination",
+        "astronomy::orbital_properties.direction_of_orbit"
       ],
-      "rowTitles": [["NEOs"], ["MBAs"], ["TNOs"], ["Comets"]],
+      "rowTitles": [
+        ["astronomy::orbital_bodies.neo_abbrev_plural"],
+        ["astronomy::orbital_bodies.mba_abbrev_plural"],
+        ["astronomy::orbital_bodies.tno_abbrev_plural"],
+        ["astronomy::orbital_bodies.comet_plural"]
+      ],
       "rows": [
         [
           { "accessor": "data", "id": "6" },
@@ -79,7 +84,7 @@
           "questionType": "textArea",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "Refer to your table of observations from the previous section.  Which of the four groups do you think this is? Explain your reasoning in terms of the unique set of orbital properties that defines this group of objects."
+          "label": "solar-system::questions.22.label"
         }
       ]
     }

--- a/src/data/pages/identifying-groups.json
+++ b/src/data/pages/identifying-groups.json
@@ -3,15 +3,15 @@
   "investigation": "solar-system",
   "sectionOrder": 0,
   "order": "11",
-  "title": "Distributions of Solar System Objects",
+  "title": "solar-system::pages.solarsystem13.title",
   "slug": "identifying-groups/",
   "previous": {
-    "title": "Comparing Orbital Properties",
-    "link": "/characterizing-orbits-4/"
+    "title": "solar-system::pages.solarsystem12.title",
+    "link": "solar-system::pages.solarsystem12.link"
   },
   "next": {
-    "title": "Progress Update",
-    "link": "/section-1/"
+    "title": "solar-system::pages.solar-system-1-break.title",
+    "link": "solar-system::pages.solar-system-1-break.link"
   },
   "layout": "TwoCol",
   "checkpoints": [
@@ -22,7 +22,7 @@
       }
     }
   ],
-  "content": "<p>Now you will explore a histogram of the number of all small Solar System objects on the y-axis vs. size of orbit on the x-axis.</p><p>Note: the scale of the y-axis changes for each of the histograms.</p><p>Click on each icon found to the left of the histogram to change the group.</p>",
+  "content": "solar-system::content.solarsystem13",
   "widgets": [
     {
       "type": "ChartSwitcher",
@@ -31,56 +31,68 @@
           "type": "OrbitalProperties",
           "source": "/data/neos/neo_semimajor_axis_hist.json",
           "options": {
-            "title": "NEO Orbit Sizes",
-            "xAxisLabel": "NEO Orbit Sizes (au)",
+            "title": "solar-system::widgets.solarsystem08.orbital_properties.0.title",
+            "xAxisLabel": "solar-system::widgets.solarsystem13.orbital_properties.0.labels.x_axis",
             "xValueAccessor": "semimajor_axis",
-            "yAxisLabel": "Number of NEOs",
+            "yAxisLabel": "solar-system::widgets.solarsystem08.orbital_properties.0.labels.y_axis",
             "domain": [[0, 100], null],
             "bins": 20,
             "tooltipAccessors": ["countOfTotal", "semimajor_axis"],
-            "tooltipLabels": ["NEOs", "Orbit Size (au)"]
+            "tooltipLabels": [
+              "astronomy::orbital_bodies.neo_abbrev_plural",
+              "astronomy::orbital_properties.size_of_orbit_with_unit"
+            ]
           }
         },
         {
           "type": "OrbitalProperties",
           "source": "/data/neos/mba_semimajor_axis_hist.json",
           "options": {
-            "title": "MBA Orbit Sizes",
-            "xAxisLabel": "MBA Orbit Sizes (au)",
+            "title": "solar-system::widgets.solarsystem09.orbital_properties.0.title",
+            "xAxisLabel": "solar-system::widgets.solarsystem13.orbital_properties.1.labels.x_axis",
             "xValueAccessor": "semimajor_axis",
-            "yAxisLabel": "Number of MBAs",
+            "yAxisLabel": "solar-system::widgets.solarsystem09.orbital_properties.0.labels.y_axis",
             "domain": [[0, 100], null],
             "bins": 20,
             "tooltipAccessors": ["countOfTotal", "semimajor_axis"],
-            "tooltipLabels": ["MBAs", "Orbit Size (au)"]
+            "tooltipLabels": [
+              "astronomy::orbital_bodies.mba_abbrev_plural",
+              "astronomy::orbital_properties.size_of_orbit_with_unit"
+            ]
           }
         },
         {
           "type": "OrbitalProperties",
           "source": "/data/neos/tno_semimajor_axis_hist.json",
           "options": {
-            "title": "TNO Orbit Sizes",
-            "xAxisLabel": "TNO Orbit Sizes (au)",
+            "title": "solar-system::widgets.solarsystem10.orbital_properties.0.title",
+            "xAxisLabel": "solar-system::widgets.solarsystem13.orbital_properties.2.labels.x_axis",
             "xValueAccessor": "semimajor_axis",
-            "yAxisLabel": "Number of TNOs",
+            "yAxisLabel": "solar-system::widgets.solarsystem10.orbital_properties.0.labels.y_axis",
             "domain": [[0, 100], null],
             "bins": 20,
             "tooltipAccessors": ["countOfTotal", "semimajor_axis"],
-            "tooltipLabels": ["TNOs", "Orbit Size (au)"]
+            "tooltipLabels": [
+              "astronomy::orbital_bodies.tno_abbrev_plural",
+              "astronomy::orbital_properties.size_of_orbit_with_unit"
+            ]
           }
         },
         {
           "type": "OrbitalProperties",
           "source": "/data/neos/comets_semimajor_axis_hist.json",
           "options": {
-            "title": "Comet Orbit Sizes",
-            "xAxisLabel": "Comet Orbit Sizes (au)",
+            "title": "solar-system::widgets.solarsystem11.orbital_properties.0.title",
+            "xAxisLabel": "solar-system::widgets.solarsystem13.orbital_properties.3.labels.x_axis",
             "xValueAccessor": "semimajor_axis",
-            "yAxisLabel": "Number of Comets",
+            "yAxisLabel": "solar-system::widgets.solarsystem11.orbital_properties.0.labels.y_axis",
             "domain": [[0, 100], null],
             "bins": 20,
             "tooltipAccessors": ["countOfTotal", "semimajor_axis"],
-            "tooltipLabels": ["Comets", "Orbit Size (au)"]
+            "tooltipLabels": [
+              "astronomy::orbital_bodies.comet_plural",
+              "astronomy::orbital_properties.size_of_orbit_with_unit"
+            ]
           }
         }
       ],
@@ -95,7 +107,7 @@
           "questionType": "textArea",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "Based on the histogram, rank the total number of small Solar System objects in each group, from most to least:"
+          "label": "solar-system::questions.200.label"
         }
       ]
     },
@@ -106,7 +118,7 @@
           "questionType": "textArea",
           "answerAccessor": "text",
           "title": "Question #2",
-          "label": "Rubin Observatory will make thousands of observations of our Solar System over the next decade. Do you think the number of any of these groups will change substantially?  Which one(s), and why?"
+          "label": "solar-system::questions.21.label"
         }
       ]
     }

--- a/src/data/pages/inclination.json
+++ b/src/data/pages/inclination.json
@@ -6,15 +6,15 @@
   "title": "solar-system::pages.solarsystem06.title",
   "slug": "inclination/",
   "previous": {
-    "title": "Eccentricity",
-    "link": "/eccentricity/"
+    "title": "solar-system::pages.solarsystem05.title",
+    "link": "solar-system::pages.solarsystem05.link"
   },
   "next": {
-    "title": "The Big View of the Solar System",
-    "link": "/big-view/"
+    "title": "solar-system::pages.solarsystem07.title",
+    "link": "solar-system::pages.solarsystem07.link"
   },
   "layout": "TwoCol",
-  "content": "<p><a href='http://rubineducation.org/glossary/inclination' target='_blank'>Inclination</a> (i) is the angle at which the object’s orbital plane (yellow) is tilted, relative to Earth’s orbital plane (blue) around the Sun. A value of 0° means that the object's orbit is parallel with Earth’s orbit. A value of 90° means that the object's orbit is tilted at a right angle to Earth’s orbit. If an object has an orbit with inclination greater than 90°, it will be orbiting in a direction opposite to Earth’s orbital direction.</p>",
+  "content": "solar-system::content.solarsystem06",
   "videos": [
     {
       "mediaPath": "20220321 Inclination animated graphic.mp4",

--- a/src/data/pages/nebula-theory.json
+++ b/src/data/pages/nebula-theory.json
@@ -3,15 +3,15 @@
   "investigation": "solar-system",
   "sectionOrder": 1,
   "order": "06",
-  "title": "Gravitational Interactions in the Solar System",
+  "title": "solar-system::pages.solarsystem19a.title",
   "slug": "nebula-theory/",
   "previous": {
-    "title": "The Formation of the Solar System",
-    "link": "/history-solar-system-1/"
+    "title": "solar-system::pages.solarsystem19.title",
+    "link": "solar-system::pages.solarsystem19.link"
   },
   "next": {
-    "title": "Progress Update",
-    "link": "/section-2/"
+    "title": "solar-system::pages.solar-system-2-break.title",
+    "link": "solar-system::pages.solar-system-2-break.link"
   },
   "layout": "TwoCol",
   "checkpoints": [
@@ -25,8 +25,8 @@
   "images": [
     {
       "mediaPath": "/images/interactions.png",
-      "altText": "Interactions between objects",
-      "figText": "How orbits of small Solar System objects can change. Credit: Rubin Observatory"
+      "altText": "solar-system::images.solarsystem19a.altText",
+      "figText": "solar-system::images.solarsystem19a.figText"
     }
   ],
   "contents": [
@@ -35,14 +35,14 @@
         "col": "left",
         "row": "top"
       },
-      "content": "<p>Although the majority of small Solar System objects have orbital characteristics that support the solar nebula theory, a small fraction of them have very eccentric or highly inclined orbits, and some even orbit the Sun in the opposite direction as the planets.</p><p>We can apply Newton’s laws and gravity to help explain these observations: </p>"
+      "content": "solar-system::content.solarsystem19a.0"
     },
     {
       "layout": {
         "col": "left",
         "row": "bottom"
       },
-      "content": "<p>From the early days of the Solar System to the present time, there have been many such interactions between objects and as a result, the orbits of some small objects in the Solar System are still changing.</p>"
+      "content": "solar-system::content.solarsystem19a.1"
     }
   ],
   "questionsByPage": [
@@ -52,23 +52,23 @@
           "id": "34",
           "questionType": "select",
           "title": "Question #1",
-          "label": "Imagine a close encounter in space between two objects, one with a large mass, and one with a small mass. As the objects approach each other, the gravitational forces they exert on each other must be equal according to Newton’s Third Law. Which object would experience a greater acceleration (change in its direction and speed)? Hint: think about Newton’s Second Law (force = mass X acceleration).",
+          "label": "solar-system::questions.34.label",
           "options": [
             {
-              "label": "The more massive object would have its direction and speed affected more",
-              "value": "The more massive object would have its direction and speed affected more"
+              "label": "solar-system::questions.34.options.0",
+              "value": "solar-system::questions.34.options.0"
             },
             {
-              "label": "The less massive object would have its direction and speed affected more",
-              "value": "The less massive object would have its direction and speed affected more"
+              "label": "solar-system::questions.34.options.1",
+              "value": "solar-system::questions.34.options.1"
             },
             {
-              "label": "Both objects would experience the same change in direction and speed",
-              "value": "Both objects would experience the same change in direction and speed"
+              "label": "solar-system::questions.34.options.2",
+              "value": "solar-system::questions.34.options.2"
             }
           ],
-          "placeholder": "Select",
-          "answerPre": "<p>Selected: </p>",
+          "placeholder": "interface::actions.select",
+          "answerPre": "interface::qas.answer_pre",
           "answerAccessor": "data"
         }
       ]
@@ -79,14 +79,20 @@
           "id": "350",
           "questionType": "compoundSelect",
           "compoundQuestion": ["350", "351"],
-          "labelPre": "In addition to mass, the distance between the two objects is a factor in determining the gravitational force between the objects. Objects that are farther apart will have a ",
-          "labelPost": " gravitational force between them",
+          "labelPre": "solar-system::questions.350.labelPre",
+          "labelPost": "solar-system::questions.350.labelPost",
           "srLabel": "...",
           "answerAccessor": "select",
-          "placeholder": "select",
+          "placeholder": "interface::actions.select",
           "options": [
-            { "label": "weaker", "value": "weaker" },
-            { "label": "stronger", "value": "stronger" }
+            {
+              "label": "interface::qas.options.weaker",
+              "value": "interface::qas.options.weaker"
+            },
+            {
+              "label": "interface::qas.options.stronger",
+              "value": "interface::qas.options.stronger"
+            }
           ],
           "answerPre": "...",
           "answerPost": "..."
@@ -95,14 +101,20 @@
           "id": "351",
           "questionType": "compoundSelect",
           "compoundQuestion": ["350", "351"],
-          "labelPre": "and are ",
-          "labelPost": " likely to experience a change in their orbits.",
+          "labelPre": "solar-system::questions.351.labelPre",
+          "labelPost": "solar-system::questions.351.labelPost",
           "srLabel": "...",
           "answerAccessor": "select",
-          "placeholder": "select",
+          "placeholder": "interface::actions.select",
           "options": [
-            { "label": "more", "value": "more" },
-            { "label": "less", "value": "less" }
+            {
+              "label": "interface::qas.options.more",
+              "value": "interface::qas.options.more"
+            },
+            {
+              "label": "interface::qas.options.less",
+              "value": "interface::qas.options.less"
+            }
           ],
           "answerPre": "...",
           "answerPost": "..."

--- a/src/data/pages/orbital-interpretation-1.json
+++ b/src/data/pages/orbital-interpretation-1.json
@@ -3,22 +3,22 @@
   "investigation": "solar-system",
   "sectionOrder": 2,
   "order": "30",
-  "title": "Student Team B’s Drawing",
+  "title": "solar-system::pages.solarsystem28.title",
   "slug": "orbital-interpretation-1/",
   "previous": {
-    "title": "Student Team A’s Drawing",
-    "link": "/orbital-interpretation/"
+    "title": "solar-system::pages.solarsystem29.title",
+    "link": "solar-system::pages.solarsystem29.link"
   },
   "next": {
-    "title": "Student Team C’s Drawing",
-    "link": "/orbital-interpretation-2/"
+    "title": "solar-system::pages.solarsystem31.title",
+    "link": "solar-system::pages.solarsystem31.link"
   },
   "layout": "SingleCol",
-  "content": "<p>The drawings above were produced by a student team to represent the data from these newly discovered small objects.</p>",
+  "content": "solar-system::content.solarsystem29",
   "images": [
     {
       "mediaPath": "/images/SS Student team drawings - Team B.svg",
-      "altText": "A student illustration of a top and side view of the solar system showing the Sun, Mars, Jupiter, and Neptune with several orbital paths that pass between Jupiter and Neptune with a range of eccentricities and inclinations.",
+      "altText": "solar-system::images.solarsystem30.altText",
       "layout": {
         "col": "left",
         "row": "top"
@@ -31,10 +31,10 @@
         "col": "left",
         "row": "top"
       },
-      "title": "Planetary Orbital Sizes",
+      "title": "solar-system::reference.planetary_orbital_sizes.title",
       "button": {
         "icon": true,
-        "text": "Planetary Orbital Sizes"
+        "text": "solar-system::reference.planetary_orbital_sizes.title"
       },
       "options": {
         "position": "right"
@@ -46,17 +46,20 @@
             "col": "left",
             "row": "top"
           },
-          "title": "Planetary Orbital Sizes",
-          "colTitles": ["Planet", "Orbit Size (au)"],
+          "title": "solar-system::reference.planetary_orbital_sizes.title",
+          "colTitles": [
+            "astronomy::orbital_bodies.planet",
+            "astronomy::orbital_properties.orbit_size_with_unit"
+          ],
           "rows": [
-            [{ "content": "Mercury" }, { "content": "0.4" }],
-            [{ "content": "Venus" }, { "content": "0.7" }],
-            [{ "content": "Earth" }, { "content": "1.0" }],
-            [{ "content": "Mars" }, { "content": "1.5" }],
-            [{ "content": "Jupiter" }, { "content": "5.2" }],
-            [{ "content": "Saturn" }, { "content": "9.5" }],
-            [{ "content": "Uranus" }, { "content": "19.2" }],
-            [{ "content": "Neptune" }, { "content": "30.1" }]
+            [{ "content": "astronomy::planets.mercury" }, { "content": "0.4" }],
+            [{ "content": "astronomy::planets.venus" }, { "content": "0.7" }],
+            [{ "content": "astronomy::planets.earth" }, { "content": "1.0" }],
+            [{ "content": "astronomy::planets.mars" }, { "content": "1.5" }],
+            [{ "content": "astronomy::planets.jupiter" }, { "content": "5.2" }],
+            [{ "content": "astronomy::planets.saturn" }, { "content": "9.5" }],
+            [{ "content": "astronomy::planets.uranus" }, { "content": "19.2" }],
+            [{ "content": "astronomy::planets.neptune" }, { "content": "30.1" }]
           ],
           "qaReview": false
         }
@@ -65,14 +68,22 @@
   ],
   "tables": [
     {
-      "id": "1",
+      "id": "newGroupProperties",
       "layout": {
         "row": "middle",
         "col": "left"
       },
       "fixed": true,
-      "colTitles": ["New Group Property", "Range", "Most Common"],
-      "rowTitles": [["Orbit Size (au)"], ["Eccentricity"], ["Inclinationº"]],
+      "colTitles": [
+        "solar-system::tables.newGroupProperties.colTitles.0",
+        "solar-system::tables.newGroupProperties.colTitles.1",
+        "solar-system::tables.newGroupProperties.colTitles.2"
+      ],
+      "rowTitles": [
+        ["astronomy::orbital_properties.orbit_size_with_unit"],
+        ["astronomy::orbital_properties.eccentricity"],
+        ["astronomy::orbital_properties.inclination_unit_symbol"]
+      ],
       "rows": [
         [
           { "accessor": "range", "id": "69a" },
@@ -98,7 +109,7 @@
           "questionType": "text",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "Do you agree or disagree with the orbital characteristics displayed in Student Team B’s drawing above? Explain your reasoning."
+          "label": "solar-system::questions.56.label"
         }
       ]
     }

--- a/src/data/pages/orbital-interpretation-2.json
+++ b/src/data/pages/orbital-interpretation-2.json
@@ -3,22 +3,22 @@
   "investigation": "solar-system",
   "sectionOrder": 2,
   "order": "31",
-  "title": "Student Team C’s Drawing",
+  "title": "solar-system::pages.solarsystem31.title",
   "slug": "orbital-interpretation-2/",
   "previous": {
-    "title": "Student Team B’s Drawing",
-    "link": "/orbital-interpretation-1/"
+    "title": "solar-system::pages.solarsystem30.title",
+    "link": "solar-system::pages.solarsystem30.link"
   },
   "next": {
-    "title": "Categorizing your New Discoveries",
-    "link": "/categorizing-new-discoveries/"
+    "title": "solar-system::pages.solarsystem33.title",
+    "link": "solar-system::pages.solarsystem33.link"
   },
   "layout": "SingleCol",
-  "content": "<p>The drawings above were produced by a student team to represent the data from these newly discovered small objects.</p>",
+  "content": "solar-system::content.solarsystem29",
   "images": [
     {
       "mediaPath": "/images/SS Student team drawings - Team C.svg",
-      "altText": "A student illustration of a top and side view of the solar system showing the Sun, Mars, Jupiter, and Neptune with several orbital paths that pass mostly between  with a range of eccentricities and inclinations.",
+      "altText": "solar-system::images.solarsystem31.altText",
       "layout": {
         "col": "left",
         "row": "top"
@@ -31,10 +31,10 @@
         "col": "left",
         "row": "top"
       },
-      "title": "Planetary Orbital Sizes",
+      "title": "solar-system::reference.planetary_orbital_sizes.title",
       "button": {
         "icon": true,
-        "text": "Planetary Orbital Sizes"
+        "text": "solar-system::reference.planetary_orbital_sizes.title"
       },
       "options": {
         "position": "right"
@@ -46,17 +46,20 @@
             "col": "left",
             "row": "top"
           },
-          "title": "Planetary Orbital Sizes",
-          "colTitles": ["Planet", "Orbit Size (au)"],
+          "title": "solar-system::reference.planetary_orbital_sizes.title",
+          "colTitles": [
+            "astronomy::orbital_bodies.planet",
+            "astronomy::orbital_properties.orbit_size_with_unit"
+          ],
           "rows": [
-            [{ "content": "Mercury" }, { "content": "0.4" }],
-            [{ "content": "Venus" }, { "content": "0.7" }],
-            [{ "content": "Earth" }, { "content": "1.0" }],
-            [{ "content": "Mars" }, { "content": "1.5" }],
-            [{ "content": "Jupiter" }, { "content": "5.2" }],
-            [{ "content": "Saturn" }, { "content": "9.5" }],
-            [{ "content": "Uranus" }, { "content": "19.2" }],
-            [{ "content": "Neptune" }, { "content": "30.1" }]
+            [{ "content": "astronomy::planets.mercury" }, { "content": "0.4" }],
+            [{ "content": "astronomy::planets.venus" }, { "content": "0.7" }],
+            [{ "content": "astronomy::planets.earth" }, { "content": "1.0" }],
+            [{ "content": "astronomy::planets.mars" }, { "content": "1.5" }],
+            [{ "content": "astronomy::planets.jupiter" }, { "content": "5.2" }],
+            [{ "content": "astronomy::planets.saturn" }, { "content": "9.5" }],
+            [{ "content": "astronomy::planets.uranus" }, { "content": "19.2" }],
+            [{ "content": "astronomy::planets.neptune" }, { "content": "30.1" }]
           ],
           "qaReview": false
         }
@@ -65,14 +68,22 @@
   ],
   "tables": [
     {
-      "id": "1",
+      "id": "newGroupProperties",
       "layout": {
         "row": "middle",
         "col": "left"
       },
       "fixed": true,
-      "colTitles": ["New Group Property", "Range", "Most Common"],
-      "rowTitles": [["Orbit Size (au)"], ["Eccentricity"], ["Inclinationº"]],
+      "colTitles": [
+        "solar-system::tables.newGroupProperties.colTitles.0",
+        "solar-system::tables.newGroupProperties.colTitles.1",
+        "solar-system::tables.newGroupProperties.colTitles.2"
+      ],
+      "rowTitles": [
+        ["astronomy::orbital_properties.orbit_size_with_unit"],
+        ["astronomy::orbital_properties.eccentricity"],
+        ["astronomy::orbital_properties.inclination_unit_symbol"]
+      ],
       "rows": [
         [
           { "accessor": "range", "id": "69a" },
@@ -98,7 +109,7 @@
           "questionType": "text",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "Do you agree or disagree with the orbital characteristics displayed in Student Team C’s drawing above? Explain your reasoning."
+          "label": "solar-system::questions.57.label"
         }
       ]
     }

--- a/src/data/pages/orbital-interpretation.json
+++ b/src/data/pages/orbital-interpretation.json
@@ -3,18 +3,18 @@
   "investigation": "solar-system",
   "sectionOrder": 2,
   "order": "29",
-  "title": "Student Team A’s Drawing",
+  "title": "solar-system::pages.solarsystem29.title",
   "slug": "orbital-interpretation/",
   "previous": {
-    "title": "Exploring A New Class of Objects",
-    "link": "/solar-system-summary/"
+    "title": "solar-system::pages.solarsystem28.title",
+    "link": "solar-system::pages.solarsystem28.link"
   },
   "next": {
-    "title": "Student Team B’s Drawing",
-    "link": "/orbital-interpretation-1/"
+    "title": "solar-system::pages.solarsystem30.title",
+    "link": "solar-system::pages.solarsystem30.link"
   },
   "layout": "SingleCol",
-  "content": "<p>The drawings above were produced by a student team to represent the data from these newly discovered small objects.</p>",
+  "content": "solar-system::content.solarsystem29",
   "questionsByPage": [
     {
       "question": [
@@ -23,7 +23,7 @@
           "questionType": "text",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "Do you agree or disagree with the orbital characteristics displayed in Student Team A’s drawing above? Explain your reasoning."
+          "label": "solar-system::questions.55.label"
         }
       ]
     }
@@ -31,7 +31,7 @@
   "images": [
     {
       "mediaPath": "/images/SS Student team drawings - Team A.svg",
-      "altText": "A student illustration of a top and side view of the solar system showing the Sun, Mars, Jupiter, and Neptune with several orbital paths that pass between Jupiter and Neptune with a range of eccentricities and similar inclinations.",
+      "altText": "solar-system::images.solarsystem29.altText",
       "layout": {
         "col": "left",
         "row": "top"
@@ -40,14 +40,22 @@
   ],
   "tables": [
     {
-      "id": "1",
+      "id": "newGroupProperties",
       "layout": {
         "row": "middle",
         "col": "left"
       },
       "fixed": true,
-      "colTitles": ["New Group Property", "Range", "Most Common"],
-      "rowTitles": [["Orbit Size (au)"], ["Eccentricity"], ["Inclinationº"]],
+      "colTitles": [
+        "solar-system::tables.newGroupProperties.colTitles.0",
+        "solar-system::tables.newGroupProperties.colTitles.1",
+        "solar-system::tables.newGroupProperties.colTitles.2"
+      ],
+      "rowTitles": [
+        ["astronomy::orbital_properties.orbit_size_with_unit"],
+        ["astronomy::orbital_properties.eccentricity"],
+        ["astronomy::orbital_properties.inclination_unit_symbol"]
+      ],
       "rows": [
         [
           { "accessor": "range", "id": "69a" },
@@ -71,10 +79,10 @@
         "col": "left",
         "row": "top"
       },
-      "title": "Planetary Orbital Sizes",
+      "title": "solar-system::reference.planetary_orbital_sizes.title",
       "button": {
         "icon": true,
-        "text": "Planetary Orbital Sizes"
+        "text": "solar-system::reference.planetary_orbital_sizes.title"
       },
       "options": {
         "position": "right"
@@ -86,17 +94,20 @@
             "col": "left",
             "row": "top"
           },
-          "title": "Planetary Orbital Sizes",
-          "colTitles": ["Planet", "Orbit Size (au)"],
+          "title": "solar-system::reference.planetary_orbital_sizes.title",
+          "colTitles": [
+            "astronomy::orbital_bodies.planet",
+            "astronomy::orbital_properties.orbit_size_with_unit"
+          ],
           "rows": [
-            [{ "content": "Mercury" }, { "content": "0.4" }],
-            [{ "content": "Venus" }, { "content": "0.7" }],
-            [{ "content": "Earth" }, { "content": "1.0" }],
-            [{ "content": "Mars" }, { "content": "1.5" }],
-            [{ "content": "Jupiter" }, { "content": "5.2" }],
-            [{ "content": "Saturn" }, { "content": "9.5" }],
-            [{ "content": "Uranus" }, { "content": "19.2" }],
-            [{ "content": "Neptune" }, { "content": "30.1" }]
+            [{ "content": "astronomy::planets.mercury" }, { "content": "0.4" }],
+            [{ "content": "astronomy::planets.venus" }, { "content": "0.7" }],
+            [{ "content": "astronomy::planets.earth" }, { "content": "1.0" }],
+            [{ "content": "astronomy::planets.mars" }, { "content": "1.5" }],
+            [{ "content": "astronomy::planets.jupiter" }, { "content": "5.2" }],
+            [{ "content": "astronomy::planets.saturn" }, { "content": "9.5" }],
+            [{ "content": "astronomy::planets.uranus" }, { "content": "19.2" }],
+            [{ "content": "astronomy::planets.neptune" }, { "content": "30.1" }]
           ],
           "qaReview": false
         }

--- a/src/data/pages/semi-major-axis.json
+++ b/src/data/pages/semi-major-axis.json
@@ -10,16 +10,16 @@
     "link": "solar-system::pages.solarsystem02.link"
   },
   "next": {
-    "title": "Eccentricity",
-    "link": "/eccentricity/"
+    "title": "solar-system::pages.solarsystem05.title",
+    "link": "solar-system::pages.solarsystem05.link"
   },
   "layout": "TwoCol",
-  "content": "<p> By making a series of careful measurements, astronomers can determine the orbit for a newly discovered Solar System object. Three properties used to describe an orbit are used throughout this investigation. </p> <p> <a href='http://rubineducation.org/glossary/orbit-size' target='_blank'>Orbital size</a> is related to the orbit's <a href='http://rubineducation.org/glossary/semi-major-axis' target='_blank'>semi-major axis</a> (which is defined as half of the longest diameter of the object's orbit). It is measured in <a href='http://rubineducation.org/glossary/astronomical-unit-au' target='_blank' >astronomical units</a> (au). You can also think of the orbit's semi-major axis as its average distance from the Sun. </p>",
+  "content": "solar-system::content.solarsystem04",
   "images": [
     {
       "mediaPath": "/images/semi-major-minor-axes.png",
-      "altText": "An image indicating the semi-major and semi-minor axis of an ellipse.",
-      "figText": "An image indicating the semi-major and semi-minor axis of an ellipse. Credit: Rubin Observatory."
+      "altText": "solar-system::images.solarsystem04.altText",
+      "figText": "solar-system::images.solarsystem04.figText"
     }
   ],
   "reference": [
@@ -46,7 +46,7 @@
           "title": "solar-system::reference.planetary_orbital_sizes.title",
           "colTitles": [
             "astronomy::orbital_bodies.planet",
-            "astronomy::orbital_properties.size_of_orbit_with_unit"
+            "astronomy::orbital_properties.orbit_size_with_unit"
           ],
           "rows": [
             [{ "content": "astronomy::planets.mercury" }, { "content": "0.4" }],

--- a/src/data/pages/solar-system-acknowledgements.json
+++ b/src/data/pages/solar-system-acknowledgements.json
@@ -3,16 +3,16 @@
   "investigation": "solar-system",
   "sectionOrder": 2,
   "order": "37",
-  "title": "Acknowledgements",
+  "title": "solar-system::pages.solarsystem37.title",
   "slug": "acknowledgements/",
   "previous": {
-    "title": "Reflect and Discuss",
-    "link": "/solar-system-discuss-report/"
+    "title": "solar-system::pages.solarsystem36.title",
+    "link": "solar-system::pages.solarsystem36.link"
   },
   "next": {
     "title": null,
     "link": null
   },
   "layout": "SingleCol",
-  "content": "<p> This investigation was created by the Education and Public Outreach program of the Vera C. Rubin Observatory Construction project. In an effort to create and test this investigation prior to the start of Operations, we rely on the data of our scientific colleagues. In particular, this investigation has made use of data and/or services provided by the International Astronomical Union’s Minor Planet Center. </p> <p>We thank the following instructors who volunteered to pilot test this investigation: <ul> <li>Chris Bolhuis, Hudsonville High School, Hudsonville, MI</li> <li>Alice Few, Pierce College Ft. Steilacoom, Lakewood, WA and Tacoma Community College, Tacoma, WA</li> <li>Scott Hildreth, Chabot College, Hayward, CA</li> <li>Joe Muise, St. Thomas More Collegiate, Burnaby, British Columbia</li> <li>Denine Voegeli, Plainview-Elgin-Millville Jr. High School, Elgin, MN</li> </ul> </p> <p> The team would also like to thank Siegfried Eggl, Henry Hsieh, and Mike Kelley for useful scientific discussions in the development of this investigation. </p> <h2>Funding Support</h2> <p> Vera C. Rubin Observatory is a Federal project jointly funded by the National Science Foundation (NSF) and the Department of Energy (DOE) Office of Science, with early construction funding received from private donations through the LSST Corporation. The NSF-funded LSST (now Rubin Observatory) Project Office for construction was established as an operating center under the management of the Association of Universities for Research in Astronomy (AURA). The DOE-funded effort to build the Rubin Observatory LSST Camera (LSSTCam) is managed by SLAC National Accelerator Laboratory (SLAC). </p>"
+  "content": "solar-system::content.solarsystem37"
 }

--- a/src/data/pages/solar-system-discuss-report.json
+++ b/src/data/pages/solar-system-discuss-report.json
@@ -3,21 +3,21 @@
   "investigation": "solar-system",
   "sectionOrder": 2,
   "order": "36",
-  "title": "Reflect and Discuss",
+  "title": "solar-system::pages.solarsystem36.title",
   "slug": "solar-system-discuss-report/",
   "previous": {
-    "title": "Putting it all Together",
-    "link": "/solar-system-summary-6/"
+    "title": "solar-system::pages.solarsystem34.title",
+    "link": "solar-system::pages.solarsystem34.link"
   },
   "next": {
-    "title": "Acknowledgements",
-    "link": "/acknowledgements/"
+    "title": "solar-system::pages.solarsystem37.title",
+    "link": "solar-system::pages.solarsystem37.link"
   },
   "layout": "TwoCol",
   "images": [
     {
       "mediaPath": "/images/thought-bubbles.png",
-      "altText": "Reflect and Discuss",
+      "altText": "solar-system::images.solarsystem36.altText",
       "figText": ""
     }
   ],
@@ -29,7 +29,7 @@
           "questionType": "textArea",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "The asteroid `Oumuamua and comet Borisov were discovered while they were passing through our Solar System, but each came from different solar systems. Based on what you have learned about gravitational interactions, provide an explanation for how these objects were able to leave their solar systems."
+          "label": "solar-system::questions.73.label"
         }
       ]
     },
@@ -40,7 +40,7 @@
           "questionType": "textArea",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "Comets often come very close to the Sun during their orbits. Comets are able to remain icy even after a close trip around the Sun. Explain how this can happen based on what you know about the changing speed of the comet during its orbit and the amount of time it spends near the Sun."
+          "label": "solar-system::questions.74.label"
         }
       ]
     }

--- a/src/data/pages/solar-system-introduction.json
+++ b/src/data/pages/solar-system-introduction.json
@@ -14,8 +14,8 @@
   "images": [
     {
       "mediaPath": "/images/orbits-of-outer-planets.jpg",
-      "altText": "solar-system::images.solarsystem00.0.altText",
-      "figText": "solar-system::images.solarsystem00.0.figText"
+      "altText": "solar-system::images.solarsystem00.altText",
+      "figText": "solar-system::images.solarsystem00.figText"
     }
   ],
   "content": "solar-system::content.solarsystem00"

--- a/src/data/pages/solar-system-section-1.json
+++ b/src/data/pages/solar-system-section-1.json
@@ -3,15 +3,15 @@
   "investigation": "solar-system",
   "sectionOrder": 0,
   "order": "12",
-  "title": "Progress Update",
+  "title": "solar-system::pages.solar-system-1-break.title",
   "slug": "section-1/",
   "previous": {
-    "title": "Distributions of Solar System Objects",
-    "link": "/identifying-groups/"
+    "title": "solar-system::pages.solarsystem13.title",
+    "link": "solar-system::pages.solarsystem13.link"
   },
   "next": {
-    "title": "Identifying Groups of Solar System Objects - 1",
-    "link": "/identifying-groups-1/"
+    "title": "solar-system::pages.solarsystem14.title",
+    "link": "solar-system::pages.solarsystem14.link"
   },
   "layout": "SectionBreak",
   "content": "solar-system::content.solarsystem-1-break"

--- a/src/data/pages/solar-system-section-2.json
+++ b/src/data/pages/solar-system-section-2.json
@@ -1,17 +1,17 @@
 {
-  "id": "solarsystem-3-0",
+  "id": "solar-system-2-break",
   "investigation": "solar-system",
   "sectionOrder": 1,
   "order": "07",
-  "title": "Progress Update",
+  "title": "solar-system::pages.solarsystem19a.title",
   "slug": "section-2/",
   "previous": {
-    "title": "Gravitational Interactions in the Solar System",
-    "link": "/nebula-theory/"
+    "title": "solar-system::pages.solarsystem19a.title",
+    "link": "solar-system::pages.solarsystem19a.link"
   },
   "next": {
-    "title": "Classifying Newly Detected Solar System Objects",
-    "link": "/classifying-objects/"
+    "title": "solar-system::pages.solarsystem22.title",
+    "link": "solar-system::pages.solarsystem22.link"
   },
   "layout": "SectionBreak",
   "content": "solar-system::content.solarsystem-2-break"

--- a/src/data/pages/solar-system-summary-6.json
+++ b/src/data/pages/solar-system-summary-6.json
@@ -3,15 +3,15 @@
   "investigation": "solar-system",
   "sectionOrder": 2,
   "order": "34",
-  "title": "Putting it all Together",
+  "title": "solar-system::pages.solarsystem34.title",
   "slug": "solar-system-summary-6/",
   "previous": {
-    "title": "Categorizing your New Discoveries",
-    "link": "/categorizing-new-discoveries/"
+    "title": "solar-system::pages.solarsystem33.title",
+    "link": "solar-system::pages.solarsystem33.link"
   },
   "next": {
-    "title": "Reflect and Discuss",
-    "link": "/solar-system-discuss-report/"
+    "title": "solar-system::pages.solarsystem36.title",
+    "link": "solar-system::pages.solarsystem36.link"
   },
   "layout": "TwoCol",
   "tables": [
@@ -23,13 +23,18 @@
       },
       "fixed": true,
       "colTitles": [
-        "Group",
-        "Size of Orbit",
-        "Eccentricity",
-        "Inclination",
-        "Direction of Orbit"
+        "astronomy::orbital_properties.group",
+        "astronomy::orbital_properties.size_of_orbit",
+        "astronomy::orbital_properties.eccentricity",
+        "astronomy::orbital_properties.inclination",
+        "astronomy::orbital_properties.direction_of_orbit"
       ],
-      "rowTitles": [["NEOs"], ["MBAs"], ["TNOs"], ["Comets"]],
+      "rowTitles": [
+        ["astronomy::orbital_bodies.neo_abbrev_plural"],
+        ["astronomy::orbital_bodies.mba_abbrev_plural"],
+        ["astronomy::orbital_bodies.tno_abbrev_plural"],
+        ["astronomy::orbital_bodies.comet_plural"]
+      ],
       "rows": [
         [
           { "accessor": "data", "id": "6" },
@@ -59,14 +64,22 @@
       "qaReview": false
     },
     {
-      "id": "2",
+      "id": "newGroupProperties",
       "layout": {
         "row": "bottom",
         "col": "right"
       },
       "fixed": true,
-      "colTitles": ["New Group Property", "Range", "Most Common"],
-      "rowTitles": [["Orbit Size (au)"], ["Eccentricity"], ["Inclinationº"]],
+      "colTitles": [
+        "solar-system::tables.newGroupProperties.colTitles.0",
+        "solar-system::tables.newGroupProperties.colTitles.1",
+        "solar-system::tables.newGroupProperties.colTitles.2"
+      ],
+      "rowTitles": [
+        ["astronomy::orbital_properties.orbit_size_with_unit"],
+        ["astronomy::orbital_properties.eccentricity"],
+        ["astronomy::orbital_properties.inclination_unit_symbol"]
+      ],
       "rows": [
         [
           { "accessor": "range", "id": "69a" },
@@ -92,7 +105,7 @@
           "questionType": "textArea",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "Which orbital characteristic(s) makes these objects different from the other four groups of objects you studied earlier? Explain."
+          "label": "solar-system::questions.80.label"
         }
       ]
     },
@@ -103,7 +116,7 @@
           "questionType": "textArea",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "You are presenting the findings of your science team at an international science conference and are sharing for the first time the name you selected for your newly discovered group of solar system objects. What name do you propose?"
+          "label": "solar-system::questions.81.label"
         }
       ]
     },
@@ -114,7 +127,7 @@
           "questionType": "textArea",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "Provide an explanation that defends why you chose this name."
+          "label": "solar-system::questions.82.label"
         }
       ]
     },
@@ -125,7 +138,7 @@
           "questionType": "textArea",
           "answerAccessor": "text",
           "title": "Question #1",
-          "label": "Your team is designing its media strategy to bring the greatest awareness to this discovery. How would you communicate your findings?"
+          "label": "solar-system::questions.83.label"
         }
       ]
     }

--- a/src/data/pages/solar-system-summary.json
+++ b/src/data/pages/solar-system-summary.json
@@ -3,15 +3,15 @@
   "investigation": "solar-system",
   "sectionOrder": 2,
   "order": "28",
-  "title": "Exploring a New Class of Objects",
+  "title": "solar-system::pages.solarsystem28.title",
   "slug": "solar-system-summary/",
   "previous": {
-    "title": "Classifying Newly Detected Solar System Objects - 3",
-    "link": "/classifying-objects-2/"
+    "title": "solar-system::pages.solarsystem24.title",
+    "link": "solar-system::pages.solarsystem24.link"
   },
   "next": {
-    "title": "Student Team A’s Drawing",
-    "link": "/orbital-interpretation/"
+    "title": "solar-system::pages.solarsystem29.title",
+    "link": "solar-system::pages.solarsystem29.link"
   },
   "layout": "TwoCol",
   "questionsByPage": [
@@ -62,12 +62,16 @@
       ],
       "tables": [
         {
-          "id": "1",
+          "id": "newGroupProperties",
           "fixed": true,
-          "colTitles": ["New Group Property", "Range", "Most Common"],
-          "label": "Your team discovers a new group of small objects that do not seem to fall into any of the four major groups you have investigated so far. Use the histograms to complete the table below.",
+          "colTitles": [
+            "solar-system::tables.newGroupProperties.colTitles.0",
+            "solar-system::tables.newGroupProperties.colTitles.1",
+            "solar-system::tables.newGroupProperties.colTitles.2"
+          ],
+          "label": "solar-system::tables.newGroupProperties.label",
           "rowTitles": [
-            ["Orbit Size (au)"],
+            ["astronomy::orbital_properties.orbit_size_with_unit"],
             ["astronomy::orbital_properties.eccentricity"],
             ["astronomy::orbital_properties.inclination_unit_symbol"]
           ],
@@ -97,42 +101,51 @@
           "type": "OrbitalProperties",
           "source": "/data/neos/final_semimajor_axis_hist.json",
           "options": {
-            "title": "Orbit Sizes",
-            "xAxisLabel": "Orbit Sizes (au)",
+            "title": "astronomy::orbital_properties.orbit_size_plural",
+            "xAxisLabel": "astronomy::orbital_properties.orbit_size_with_unit_plural",
             "xValueAccessor": "semimajor_axis",
-            "yAxisLabel": "Number of Objects",
+            "yAxisLabel": "solar-system::widgets.solarsystem19.orbital_properties.labels.y_axis",
             "domain": [[0, 30], null],
             "bins": 10,
             "tooltipAccessors": ["countOfTotal", "semimajor_axis"],
-            "tooltipLabels": ["Objects", "Orbit Size (au)"]
+            "tooltipLabels": [
+              "solar-system::widgets.solarsystem19.orbital_properties.labels.tooltip",
+              "astronomy::orbital_properties.orbit_size_with_unit"
+            ]
           }
         },
         {
           "type": "OrbitalProperties",
           "source": "/data/neos/final_eccentricity_hist.json",
           "options": {
-            "title": "Eccentricities",
-            "xAxisLabel": "Eccentricities",
-            "yAxisLabel": "Number of Objects",
+            "title": "astronomy::orbital_properties.eccentricity_plural",
+            "xAxisLabel": "astronomy::orbital_properties.eccentricity_plural",
+            "yAxisLabel": "solar-system::widgets.solarsystem19.orbital_properties.labels.y_axis",
             "xValueAccessor": "eccentricity",
             "domain": [[0, 1], null],
             "bins": 20,
             "tooltipAccessors": ["countOfTotal", "eccentricity"],
-            "tooltipLabels": ["Objects", "Eccentricity"]
+            "tooltipLabels": [
+              "solar-system::widgets.solarsystem19.orbital_properties.labels.tooltip",
+              "astronomy::orbital_properties.eccentricity"
+            ]
           }
         },
         {
           "type": "OrbitalProperties",
           "source": "/data/neos/final_inclination_hist.json",
           "options": {
-            "title": "Inclinations",
-            "xAxisLabel": "Inclinations (degrees)",
-            "yAxisLabel": "Number of Objects",
+            "title": "astronomy::orbital_properties.inclination_plural",
+            "xAxisLabel": "astronomy::orbital_properties.inclination_unit_plural",
+            "yAxisLabel": "solar-system::widgets.solarsystem19.orbital_properties.labels.y_axis",
             "xValueAccessor": "inclination",
             "domain": [[0, 180], []],
             "bins": 18,
             "tooltipAccessors": ["countOfTotal", "inclination"],
-            "tooltipLabels": ["Objects", "Inclination (degrees)"]
+            "tooltipLabels": [
+              "solar-system::widgets.solarsystem19.orbital_properties.labels.tooltip",
+              "astronomy::orbital_properties.inclination_unit"
+            ]
           }
         }
       ],


### PR DESCRIPTION
For git: "Resolves EPO-6204"
For JIRA: "EPO-6204 #IN-REVIEW #comment move StSS content to key-values"

JIRA: https://jira.lsstcorp.org/browse/EPO-6204

## What this change does ##

Moves all of the content for Surveying the Solar System out of it's page JSON files and into translation files. Additionally makes a handful of code changes to better translation and avoid double-translating content.

## Notes for reviewers ##

This change impacts every page of Surveying the Solar System although it should be an invisible change, the English content should not be visibly different in any way. 

Include an indication of how detailed a review you want on a 1-10 scale.
- 6

## Testing ##

Test using the deployment attached to this pull request, clear the local cache first. A simple test would be to visit each page of the investigation and look for obviously missing or untranslated content. 

An additional test can be done by running the code locally and in `gatsby-config.js` setting `debug: true` in the i18next configuration and going through each page and checking for debug messages indicating a key does not have a value. There should be a small number of keys that will display, mostly these are rows of tables that are attempted to be translated but have not been put in key-value pairs because they are not localizable (numbers)

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
