### PR TITLE
[F] Add debug output to investigations

### DIFF
--- a/src/components/site/debug/index.jsx
+++ b/src/components/site/debug/index.jsx
@@ -1,0 +1,43 @@
+/* eslint-disable no-bitwise */
+import React from 'reactn';
+import { Trans } from 'gatsby-plugin-react-i18next';
+import ls from 'local-storage';
+
+class Debug extends React.PureComponent {
+  getDownloadLink = () => {
+    const savedState = JSON.stringify(ls(this.global.investigation));
+    const savedStateHash = this.hashKeys(Object.keys(savedState));
+    const state = JSON.stringify(this.global);
+    const stateHash = this.hashKeys(Object.keys(state));
+    const browser = navigator.userAgent;
+    const location = window.location.href;
+    const online = navigator.onLine;
+    const date = new Date();
+    const dimensions = `${window.innerWidth}px x ${window.innerHeight}px`;
+
+    const data = new Blob(
+      [
+        `Location: ${location}\nDate: ${date}\nBrowser: ${browser}\nOnline: ${online}\nDimensions: ${dimensions}\n\nLocal storage - ${savedStateHash}\n${savedState}\n\nState - ${stateHash}\n${state}`,
+      ],
+      { type: 'text/plain' }
+    );
+    return window.URL.createObjectURL(data);
+  };
+
+  getFileName = () => `debug-${new Date().getTime()}.txt`;
+
+  hashKeys = keys =>
+    keys.reduce((hash, char) => 0 | (31 * hash + char.charCodeAt(0)), 0);
+
+  render = () => (
+    <a
+      href={this.getDownloadLink()}
+      download={this.getFileName()}
+      type="text/plain"
+    >
+      <Trans>interface::actions.debug</Trans>
+    </a>
+  );
+}
+
+export default Debug;

--- a/src/containers/LandingContainer.jsx
+++ b/src/containers/LandingContainer.jsx
@@ -10,6 +10,7 @@ import Link from '../components/site/link';
 import SEO from '../components/seo';
 import Button from '../components/site/button/index.js';
 import EducatorModeToggle from '../components/site/educatorModeToggle';
+import Debug from '../components/site/debug';
 
 @reactn
 class InvestigationsLanding extends React.PureComponent {
@@ -90,19 +91,20 @@ class InvestigationsLanding extends React.PureComponent {
                     >
                       <Trans>interface::actions.review_your_answers</Trans>
                     </Button>
+                    <Button
+                      flat
+                      primary
+                      swapTheming
+                      onClick={this.dispatch.empty}
+                      style={{ backgroundColor: '#df0039' }}
+                    >
+                      <Trans>interface::actions.clear_answers</Trans>
+                    </Button>
                   </div>
-                  <Button
-                    flat
-                    primary
-                    swapTheming
-                    onClick={this.dispatch.empty}
-                    style={{ backgroundColor: '#df0039' }}
-                  >
-                    <Trans>interface::actions.clear_answers</Trans>
-                  </Button>
                 </div>
               </>
             )}
+            <Button flat primary component={Debug} />
           </>
         ) : (
           investigations.map(investigation => {

--- a/src/data/locales/en/interface.json
+++ b/src/data/locales/en/interface.json
@@ -5,6 +5,7 @@
     "checkpoint": "Checkpoint"
   },
   "actions": {
+    "debug": "Debug",
     "review_your_answers": "Review your answers",
     "clear_answers": "Clear all saved answers",
     "go_to_investigation": "Go to {{investigation}} investigation",


### PR DESCRIPTION
For git: "Resolves EPO-6248"
For JIRA: "EPO-6248 #IN-REVIEW #comment add debug output to investigations"

JIRA: https://jira.lsstcorp.org/browse/EPO-6248

## What this change does ##

Add a debugging tool that downloads an output containing the current application state with additional information like browser agent, online status, timestamp, and current URL

## Notes for reviewers ##

Include an indication of how detailed a review you want on a 1-10 scale.
- 1 = "I barely need review on this"

## Testing ##

Test by loading the landing page of investigations and clicking the new "debug" link at the bottom of the page. Verify that a txt file downloads and contains information.

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
