### PR TITLE
[C] reset global state when clearing answers

### DIFF
--- a/src/components/site/debug/index.jsx
+++ b/src/components/site/debug/index.jsx
@@ -1,15 +1,23 @@
 /* eslint-disable no-bitwise */
-import React from 'reactn';
+import React, { useGlobal } from 'reactn';
 import { Trans } from 'gatsby-plugin-react-i18next';
 import ls from 'local-storage';
 
-class Debug extends React.PureComponent {
-  getDownloadLink = () => {
-    if (this.isBrowser()) {
-      const savedState = JSON.stringify(ls(this.global.investigation));
-      const savedStateHash = this.hashKeys(Object.keys(savedState));
-      const state = JSON.stringify(this.global);
-      const stateHash = this.hashKeys(Object.keys(state));
+const Debug = () => {
+  const getFileName = () => `debug-${new Date().getTime()}.txt`;
+
+  const hashKeys = keys =>
+    keys.reduce((hash, char) => 0 | (31 * hash + char.charCodeAt(0)), 0);
+
+  const isBrowser = () => typeof window !== 'undefined';
+
+  const getDownloadLink = () => {
+    if (isBrowser()) {
+      const [global] = useGlobal();
+      const savedState = JSON.stringify(ls(global.investigation));
+      const savedStateHash = hashKeys(Object.keys(savedState));
+      const state = JSON.stringify(global);
+      const stateHash = hashKeys(Object.keys(state));
       const browser = navigator.userAgent;
       const location = window.location.href;
       const online = navigator.onLine;
@@ -18,7 +26,7 @@ class Debug extends React.PureComponent {
 
       const data = new Blob(
         [
-          `Location: ${location}\nDate: ${date}\nBrowser: ${browser}\nOnline: ${online}\nDimensions: ${dimensions}\n\nLocal storage - ${savedStateHash}\n${savedState}\n\nState - ${stateHash}\n${state}`,
+          `Location: ${location}\nDate: ${date}\nBrowser: ${browser}\nOnline: ${online}\nDimensions: ${dimensions}\n\nLocal storage: ${savedStateHash}\n${savedState}\n\nState: ${stateHash}\n${state}`,
         ],
         { type: 'text/plain' }
       );
@@ -28,22 +36,35 @@ class Debug extends React.PureComponent {
     return '';
   };
 
-  getFileName = () => `debug-${new Date().getTime()}.txt`;
-
-  hashKeys = keys =>
-    keys.reduce((hash, char) => 0 | (31 * hash + char.charCodeAt(0)), 0);
-
-  isBrowser = () => typeof window !== 'undefined';
-
-  render = () => (
-    <a
-      href={this.getDownloadLink()}
-      download={this.getFileName()}
-      type="text/plain"
-    >
-      <Trans>interface::actions.debug</Trans>
-    </a>
+  return (
+    <>
+      <h3>
+        <Trans>interface::debug.title</Trans>
+      </h3>
+      <p>
+        <Trans i18nKey="interface::debug.instructions">
+          If your application is experiencing issues that cannot be solved by
+          clearing saved answers,
+          <a
+            href={getDownloadLink()}
+            download={getFileName()}
+            type="text/plain"
+          >
+            download this debug log
+          </a>
+          and attach it in an email to our developers at
+          <a
+            href="mailto:education@lsst.org"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            education@lsst.org
+          </a>
+          .
+        </Trans>
+      </p>
+    </>
   );
-}
+};
 
 export default Debug;

--- a/src/data/locales/en/interface.json
+++ b/src/data/locales/en/interface.json
@@ -5,7 +5,6 @@
     "checkpoint": "Checkpoint"
   },
   "actions": {
-    "debug": "Debug",
     "review_your_answers": "Review your answers",
     "clear_answers": "Clear all saved answers",
     "go_to_investigation": "Go to {{investigation}} investigation",
@@ -21,6 +20,10 @@
     "change_answer": "Change answer",
     "select": "Select",
     "select_type": "Select a type"
+  },
+  "debug": {
+    "title": "Experiencing issues?",
+    "instructions": "If your application is experiencing issues that cannot be solved by clearing saved answers, <1>download this debug log</1> and attach it in an email to our developers at <3>education@lsst.org</3>."
   },
   "errors": {
     "qas": {

--- a/src/layouts/index.jsx
+++ b/src/layouts/index.jsx
@@ -38,18 +38,6 @@ class Layout extends React.Component {
     this.store.addReducers();
   }
 
-  getCheckpoints = () => {
-    const { pages } = this.state;
-
-    return pages.reduce((checkpoints, page) => {
-      if (page.checkpoints && page.checkpoints.length) {
-        checkpoints.push(page.pageNumber);
-      }
-
-      return checkpoints;
-    }, []);
-  };
-
   getSections = id => {
     const { pages } = this.state;
     const { investigations } = this.props;
@@ -155,7 +143,6 @@ class Layout extends React.Component {
       totalQAsByInvestigation: this.getTotalQAs(),
       totalQAsByPage: this.getTotalQAsByPage(),
       questionNumbersByPage: this.getQuestionNumbersByPage(),
-      checkpoints: this.getCheckpoints(),
       sections: this.getSections(id),
     };
   }

--- a/src/state/GlobalStore.js
+++ b/src/state/GlobalStore.js
@@ -1,4 +1,4 @@
-import { addCallback, addReducer, setGlobal } from 'reactn';
+import { addCallback, addReducer, setGlobal, resetGlobal } from 'reactn';
 import ls from 'local-storage';
 import filter from 'lodash/filter';
 import uniq from 'lodash/uniq';
@@ -20,7 +20,6 @@ class GlobalStore {
       totalQAsByInvestigation: null,
       totalQAsByPage: null,
       questionNumbersByPage: null,
-      checkpoints: [],
       educatorMode: null,
       sections: [],
       savedSources: {},
@@ -28,7 +27,6 @@ class GlobalStore {
     };
     const { investigation } = this.emptyState;
 
-    // const existingState = this.emptyState;
     const existingState = ls(investigation) || this.emptyState;
 
     setGlobal(existingState);
@@ -43,6 +41,10 @@ class GlobalStore {
 
   addReducers() {
     addReducer('empty', () => {
+      resetGlobal();
+      this.addCallbacks();
+      this.addReducers();
+
       return this.emptyState;
     });
 
@@ -52,14 +54,6 @@ class GlobalStore {
         name,
       };
     });
-
-    // addReducer(
-    //   'updateGlobalFromInvestigation',
-    //   (global, dispatch, investigationId) => {
-    //     console.log(investigationId, ls(investigationId) || this.emptyState);
-    //     return ls(investigationId) || this.emptyState;
-    //   }
-    // );
 
     addReducer('updatePageId', (global, dispatch, pageId) => {
       const {


### PR DESCRIPTION
For git: "Resolves EPO-6247"
For JIRA: "EPO-6247 #IN-REVIEW #comment reset global state when clearing"

JIRA: https://jira.lsstcorp.org/browse/EPO-6247

## What this change does ##

Resolves a bug where when resetting the global state, the callback updates the local storage with the global state pre-reset. This would result in not being able to clean out old code stored locally. Instead reactn's built-in reset tool is used and the callbacks and reducers are reset at the same time.

## Notes for reviewers ##

Where should the reviewer look for the change?  Do they review the change on the frontend?  How extensive is the change?  Does it affect Components used in a variety of contexts?  Anything you'd like reviewers to pay particular attention to or questions you have about the change.

Include an indication of how detailed a review you want on a 1-10 scale.
- 2

## Testing ##

This change can be tested by adding a new property to the local storage ex. `bogus: true`, clicking "clear all answers" and then checking that the local storage no longer has the added property i.e. it matches the empty state defined in the application

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
