### PR TITLE
[C] only translate select labels

### DIFF
--- a/src/components/qas/questions/qaMultiSelect/index.jsx
+++ b/src/components/qas/questions/qaMultiSelect/index.jsx
@@ -90,19 +90,22 @@ class QAMultiSelect extends React.PureComponent {
   };
 
   getMultiSelectOptions = options => {
+    const { t } = this.props;
     const { selectedOptions } = this.state;
     return options.map(option => {
+      const { label, value } = option;
+      const translatedLabel = t(label);
       return (
         <SelectionControl
-          key={`${option.label}_${option.value}`}
-          id={`qa-multi-select-${option.value}`}
+          key={`${translatedLabel}_${value}`}
+          id={`qa-multi-select-${value}`}
           checkedCheckboxIcon={<CheckBox />}
           uncheckedCheckboxIcon={<CheckBoxOutlineBlank />}
           name="selectedOptions[]"
-          label={option.label}
+          label={translatedLabel}
           type="checkbox"
-          defaultChecked={selectedOptions.indexOf(option.value) > -1}
-          value={option.value}
+          defaultChecked={selectedOptions.indexOf(value) > -1}
+          value={value}
           onClick={this.handleStoredOptions}
         />
       );
@@ -167,8 +170,8 @@ class QAMultiSelect extends React.PureComponent {
           {qaReview && (
             <span className={qaStyles.qaReviewBlock}>
               <span className={qaStyles.answerContentSelect}>
-                {selectedOptions.join(', ') ||
-                  t('errors.qas.answer_not_selected')}
+                {selectedOptions.map(t).join(', ') ||
+                  t('interface::errors.qas.answer_not_selected')}
               </span>
             </span>
           )}
@@ -229,4 +232,4 @@ QAMultiSelect.propTypes = {
   t: PropTypes.func,
 };
 
-export default withTranslation('interface')(QAMultiSelect);
+export default withTranslation()(QAMultiSelect);

--- a/src/components/qas/questions/qaSelect/index.jsx
+++ b/src/components/qas/questions/qaSelect/index.jsx
@@ -82,9 +82,10 @@ class QASelect extends React.PureComponent {
     const { t } = this.props;
 
     return options.map(option => {
+      const { label, value } = option;
       return {
-        label: t(option.label),
-        value: t(option.value),
+        label: t(label),
+        value,
       };
     });
   };
@@ -178,8 +179,8 @@ class QASelect extends React.PureComponent {
                 })}
               >
                 {answered
-                  ? answer.content || answer.data
-                  : t('errors.qas.answer_not_selected')}
+                  ? t(answer.content) || t(answer.data)
+                  : t('interface::errors.qas.answer_not_selected')}
               </div>
             </div>
           )}
@@ -225,4 +226,4 @@ QASelect.propTypes = {
   t: PropTypes.func,
 };
 
-export default withTranslation('interface')(QASelect);
+export default withTranslation()(QASelect);


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-7066

## What this change does ##

Instead of translating labels and values for selections, only translate the labels so that the value key can be preserved and answers be able to change between locales

## Notes for reviewers ##

Fill out answers up to a single or multi-select answer, make a selection then change the locale and verify the selection is preserved when locales change. Verify the selection is preserved on the QAReview page when locale is changed

Include an indication of how detailed a review you want on a 1-10 scale.
- 3

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [ ] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
