### PR TITLE
[F] Add Hubble plotter slider

### DIFF
--- a/src/components/charts/hubblePlot/Nudge.jsx
+++ b/src/components/charts/hubblePlot/Nudge.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Button from '../../site/button';
@@ -84,24 +84,24 @@ const Nudge = ({
     setPressing(false);
   };
 
-  const onKeyDown = event => {
+  const onKeyDown = useCallback(event => {
     const { key } = event;
 
     if (datum && key.includes('Arrow')) {
       arrowDownCallback(key);
     }
-  };
+  });
 
   const setEventHandlers = () => {
     const { current: element } = arrowsRef;
-    element.addEventListener('keydown', onKeyDown);
-    element.addEventListener('keyup', arrowUpCallback);
+    element.addEventListener('keydown', onKeyDown, { passive: false });
+    element.addEventListener('keyup', arrowUpCallback, { passive: true });
   };
 
   const removeEventHandlers = () => {
     const { current: element } = arrowsRef;
-    element.removeEventListener('keydown', onKeyDown);
-    element.removeEventListener('keyup', arrowUpCallback);
+    element.removeEventListener('keydown', onKeyDown, { passive: false });
+    element.removeEventListener('keyup', arrowUpCallback, { passive: true });
   };
 
   return (

--- a/src/components/charts/hubblePlot/Nudge.jsx
+++ b/src/components/charts/hubblePlot/Nudge.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Button from '../../site/button';
@@ -12,100 +12,133 @@ import {
   nudgeDown,
   nudgeUp,
   nudge,
+  nudgeFiller,
 } from './hubble-plot.module.scss';
 
 const Nudge = ({
   show,
-  mouseDownCallback,
-  mouseUpCallback,
+  arrowDownCallback,
+  arrowUpCallback,
   xValueAccessor,
   yValueAccessor,
   xScale,
   yScale,
   data,
   offsetTop,
-  chartScale,
 }) => {
+  const width = 80;
+  const arrows = [
+    { icon: ArrowLeft, key: 'ArrowUp', cssClass: nudgeUp, srText: 'Up' },
+    {
+      icon: ArrowRight,
+      key: 'ArrowRight',
+      cssClass: nudgeRight,
+      srText: 'Right',
+    },
+    {
+      icon: ArrowRight,
+      key: 'ArrowDown',
+      cssClass: nudgeDown,
+      srText: 'Down',
+    },
+    {
+      icon: ArrowLeft,
+      key: 'ArrowLeft',
+      cssClass: nudgeLeft,
+      srText: 'Left',
+    },
+  ];
+
   const [timer, setTimer] = useState();
   const [pressing, setPressing] = useState(false);
   const [direction, setDirection] = useState();
+  const arrowsRef = useRef();
+
   const [datum] = data || [];
   const { [xValueAccessor]: datumX, [yValueAccessor]: datumY } = datum || {};
-
   const opacity = show ? 1 : 0;
-  const left = `${xScale(datumX) * chartScale}px`;
-  const top = `${(yScale(datumY) + offsetTop) * chartScale}px`;
+  const x = xScale(datumX) - width / 2 || 0;
+  const y = yScale(datumY) + offsetTop - width / 2 || 0;
 
   useEffect(() => {
     if (pressing && direction) {
-      mouseDownCallback(direction);
-      const interval = setInterval(() => mouseDownCallback(direction), 100);
+      arrowDownCallback(direction);
+      const interval = setInterval(() => arrowDownCallback(direction), 100);
       setTimer(interval);
     } else {
       clearInterval(timer);
-      mouseUpCallback();
+      arrowUpCallback();
     }
   }, [pressing]);
 
-  const handlePressingDown = clickDirection => {
-    setPressing(true);
-    setDirection(clickDirection);
+  const handlePressingDown = (event, clickDirection) => {
+    const { button } = event;
+
+    if (button === 0) {
+      setPressing(true);
+      setDirection(clickDirection);
+    }
   };
 
   const handleNotPressingDown = () => {
     setPressing(false);
   };
 
-  return (
-    <div className={nudgeContainer} style={{ opacity, left, top }}>
-      <Button
-        icon
-        iconEl={<ButtonIcon srText="Up" Icon={ArrowLeft} />}
-        className={classNames(nudge, nudgeUp)}
-        onMouseDown={() => handlePressingDown('ArrowUp')}
-        onMouseUp={handleNotPressingDown}
-        onMouseLeave={handleNotPressingDown}
-        disabled={!show}
-      />
-      <Button
-        icon
-        iconEl={<ButtonIcon srText="Right" Icon={ArrowRight} />}
-        className={classNames(nudge, nudgeRight)}
-        onMouseDown={() => handlePressingDown('ArrowRight')}
-        onMouseUp={handleNotPressingDown}
-        onMouseLeave={handleNotPressingDown}
-        disabled={!show}
-      />
-      <Button
-        icon
-        iconEl={<ButtonIcon srText="Down" Icon={ArrowRight} />}
-        className={classNames(nudge, nudgeDown)}
-        onMouseDown={() => handlePressingDown('ArrowDown')}
-        onMouseUp={handleNotPressingDown}
-        onMouseLeave={handleNotPressingDown}
-        disabled={!show}
-      />
-      <Button
-        icon
-        iconEl={<ButtonIcon srText="Left" Icon={ArrowLeft} />}
-        className={classNames(nudge, nudgeLeft)}
-        onMouseDown={() => handlePressingDown('ArrowLeft')}
-        onMouseUp={handleNotPressingDown}
-        onMouseLeave={handleNotPressingDown}
-        disabled={!show}
-      />
-    </div>
-  );
-};
+  const onKeyDown = event => {
+    const { key } = event;
 
-Nudge.defaultProps = {
-  chartScale: 1,
+    if (datum && key.includes('Arrow')) {
+      arrowDownCallback(key);
+    }
+  };
+
+  const setEventHandlers = () => {
+    const { current: element } = arrowsRef;
+    element.addEventListener('keydown', onKeyDown);
+    element.addEventListener('keyup', arrowUpCallback);
+  };
+
+  const removeEventHandlers = () => {
+    const { current: element } = arrowsRef;
+    element.removeEventListener('keydown', onKeyDown);
+    element.removeEventListener('keyup', arrowUpCallback);
+  };
+
+  return (
+    <foreignObject {...{ x, y, width }} height={width}>
+      <div
+        className={nudgeContainer}
+        style={{ opacity }}
+        onFocus={setEventHandlers}
+        onBlur={removeEventHandlers}
+        ref={arrowsRef}
+      >
+        {arrows.map(arrow => {
+          const { icon: Icon, key, cssClass, srText } = arrow;
+
+          return (
+            <Button
+              key={key}
+              icon
+              iconEl={<ButtonIcon {...{ Icon, srText }} />}
+              className={classNames(nudge, cssClass)}
+              onMouseDown={e => handlePressingDown(e, key)}
+              onMouseUp={handleNotPressingDown}
+              onMouseLeave={handleNotPressingDown}
+              disabled={!show}
+            />
+          );
+        })}
+        <div className={nudgeFiller} />
+      </div>
+    </foreignObject>
+  );
 };
 
 Nudge.propTypes = {
   show: PropTypes.bool,
-  mouseDownCallback: PropTypes.func,
-  mouseUpCallback: PropTypes.func,
+  arrowDownCallback: PropTypes.func,
+  arrowUpCallback: PropTypes.func,
   offsetTop: PropTypes.number,
   xValueAccessor: PropTypes.string,
   yValueAccessor: PropTypes.string,

--- a/src/components/charts/hubblePlot/Nudge.jsx
+++ b/src/components/charts/hubblePlot/Nudge.jsx
@@ -1,0 +1,118 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import Button from '../../site/button';
+import ButtonIcon from '../../site/button/ButtonIcon';
+import ArrowLeft from '../../site/icons/ArrowLeft';
+import ArrowRight from '../../site/icons/ArrowRight';
+import {
+  nudgeContainer,
+  nudgeRight,
+  nudgeLeft,
+  nudgeDown,
+  nudgeUp,
+  nudge,
+} from './hubble-plot.module.scss';
+
+const Nudge = ({
+  show,
+  mouseDownCallback,
+  mouseUpCallback,
+  xValueAccessor,
+  yValueAccessor,
+  xScale,
+  yScale,
+  data,
+  offsetTop,
+  chartScale,
+}) => {
+  const [timer, setTimer] = useState();
+  const [pressing, setPressing] = useState(false);
+  const [direction, setDirection] = useState();
+  const [datum] = data || [];
+  const { [xValueAccessor]: datumX, [yValueAccessor]: datumY } = datum || {};
+
+  const opacity = show ? 1 : 0;
+  const left = `${xScale(datumX) * chartScale}px`;
+  const top = `${(yScale(datumY) + offsetTop) * chartScale}px`;
+
+  useEffect(() => {
+    if (pressing && direction) {
+      mouseDownCallback(direction);
+      const interval = setInterval(() => mouseDownCallback(direction), 100);
+      setTimer(interval);
+    } else {
+      clearInterval(timer);
+      mouseUpCallback();
+    }
+  }, [pressing]);
+
+  const handlePressingDown = clickDirection => {
+    setPressing(true);
+    setDirection(clickDirection);
+  };
+
+  const handleNotPressingDown = () => {
+    setPressing(false);
+  };
+
+  return (
+    <div className={nudgeContainer} style={{ opacity, left, top }}>
+      <Button
+        icon
+        iconEl={<ButtonIcon srText="Up" Icon={ArrowLeft} />}
+        className={classNames(nudge, nudgeUp)}
+        onMouseDown={() => handlePressingDown('ArrowUp')}
+        onMouseUp={handleNotPressingDown}
+        onMouseLeave={handleNotPressingDown}
+        disabled={!show}
+      />
+      <Button
+        icon
+        iconEl={<ButtonIcon srText="Right" Icon={ArrowRight} />}
+        className={classNames(nudge, nudgeRight)}
+        onMouseDown={() => handlePressingDown('ArrowRight')}
+        onMouseUp={handleNotPressingDown}
+        onMouseLeave={handleNotPressingDown}
+        disabled={!show}
+      />
+      <Button
+        icon
+        iconEl={<ButtonIcon srText="Down" Icon={ArrowRight} />}
+        className={classNames(nudge, nudgeDown)}
+        onMouseDown={() => handlePressingDown('ArrowDown')}
+        onMouseUp={handleNotPressingDown}
+        onMouseLeave={handleNotPressingDown}
+        disabled={!show}
+      />
+      <Button
+        icon
+        iconEl={<ButtonIcon srText="Left" Icon={ArrowLeft} />}
+        className={classNames(nudge, nudgeLeft)}
+        onMouseDown={() => handlePressingDown('ArrowLeft')}
+        onMouseUp={handleNotPressingDown}
+        onMouseLeave={handleNotPressingDown}
+        disabled={!show}
+      />
+    </div>
+  );
+};
+
+Nudge.defaultProps = {
+  chartScale: 1,
+};
+
+Nudge.propTypes = {
+  show: PropTypes.bool,
+  mouseDownCallback: PropTypes.func,
+  mouseUpCallback: PropTypes.func,
+  offsetTop: PropTypes.number,
+  xValueAccessor: PropTypes.string,
+  yValueAccessor: PropTypes.string,
+  xScale: PropTypes.func,
+  yScale: PropTypes.func,
+  data: PropTypes.array,
+  chartScale: PropTypes.number,
+};
+
+export default Nudge;

--- a/src/components/charts/hubblePlot/Points.jsx
+++ b/src/components/charts/hubblePlot/Points.jsx
@@ -6,13 +6,6 @@ import Point from './Point.jsx';
 import { notActive, invisible } from './hubble-plot.module.scss';
 
 class Points extends React.PureComponent {
-  classify(name) {
-    name
-      .toLowerCase()
-      .split(' ')
-      .join('-');
-  }
-
   render() {
     const {
       data,

--- a/src/components/charts/hubblePlot/hubble-plot.module.scss
+++ b/src/components/charts/hubblePlot/hubble-plot.module.scss
@@ -175,22 +175,23 @@ nav {
 }
 
 .nudge-container {
-  $base: 20px;
   position: absolute;
   display: grid;
   grid-template-rows: repeat(3, 1fr);
   grid-template-columns: repeat(3, 1fr);
-  width: $base * 3;
-  height: $base * 3;
-  pointer-events: none;
-  transform: translate(-50%, -50%);
+  width: 100%;
+  height: 100%;
 
   .nudge {
-    width: $base;
-    height: $base;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
     padding: 0;
     margin: 0;
-    pointer-events: auto;
+    background: $white;
+    border: 1px solid #555;
 
     + .nudge {
       margin: 0;
@@ -200,7 +201,10 @@ nav {
   .nudge-up,
   .nudge-down {
     grid-column: 2;
-    transform: rotate(90deg);
+
+    svg {
+      transform: rotate(90deg);
+    }
   }
 
   .nudge-right,
@@ -208,19 +212,49 @@ nav {
     grid-row: 2;
   }
 
+  .nudge-right,
+  .nudge-down {
+    border-top-left-radius: 0;
+  }
+
+  .nudge-left,
+  .nudge-down {
+    border-top-right-radius: 0;
+  }
+
+  .nudge-left,
+  .nudge-up {
+    border-bottom-right-radius: 0;
+  }
+
+  .nudge-up,
+  .nudge-right {
+    border-bottom-left-radius: 0;
+  }
+
   .nudge-right {
     grid-column: 3;
+    border-left-width: 0;
   }
 
   .nudge-left {
     grid-column: 1;
+    border-right-width: 0;
   }
 
   .nudge-up {
     grid-row: 1;
+    border-bottom-width: 0;
   }
 
   .nudge-down {
     grid-row: 3;
+    border-top-width: 0;
+  }
+
+  .nudge-filler {
+    grid-row: 2;
+    grid-column: 2;
+    background: $white;
   }
 }

--- a/src/components/charts/hubblePlot/hubble-plot.module.scss
+++ b/src/components/charts/hubblePlot/hubble-plot.module.scss
@@ -164,3 +164,12 @@ nav {
     }
   }
 }
+
+.hubble-plot-zoom {
+  $width: 40%;
+  position: absolute;
+  right: $minPadding;
+  bottom: $width * 1.33;
+  width: $width;
+  transform-origin: right;
+}

--- a/src/components/charts/hubblePlot/hubble-plot.module.scss
+++ b/src/components/charts/hubblePlot/hubble-plot.module.scss
@@ -173,3 +173,54 @@ nav {
   width: $width;
   transform-origin: right;
 }
+
+.nudge-container {
+  $base: 20px;
+  position: absolute;
+  display: grid;
+  grid-template-rows: repeat(3, 1fr);
+  grid-template-columns: repeat(3, 1fr);
+  width: $base * 3;
+  height: $base * 3;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+
+  .nudge {
+    width: $base;
+    height: $base;
+    padding: 0;
+    margin: 0;
+    pointer-events: auto;
+
+    + .nudge {
+      margin: 0;
+    }
+  }
+
+  .nudge-up,
+  .nudge-down {
+    grid-column: 2;
+    transform: rotate(90deg);
+  }
+
+  .nudge-right,
+  .nudge-left {
+    grid-row: 2;
+  }
+
+  .nudge-right {
+    grid-column: 3;
+  }
+
+  .nudge-left {
+    grid-column: 1;
+  }
+
+  .nudge-up {
+    grid-row: 1;
+  }
+
+  .nudge-down {
+    grid-row: 3;
+  }
+}

--- a/src/components/charts/hubblePlot/index.jsx
+++ b/src/components/charts/hubblePlot/index.jsx
@@ -726,7 +726,7 @@ class HubblePlot extends React.Component {
       currentScale,
     } = this.state;
 
-    const { userTrendline, multiple } = options || {};
+    const { userTrendline, multiple, createUserHubblePlot } = options || {};
 
     const svgClasses = classnames('svg-chart', hubblePlot, {
       'hide-plot': !isVisible,
@@ -742,14 +742,16 @@ class HubblePlot extends React.Component {
         className={`svg-container ${hubblePlotContainer}`}
         data-testid="hubble-plot"
       >
-        <SliderVertical
-          className={hubblePlotZoom}
-          min={minZoom}
-          max={maxZoom}
-          step={(maxZoom - minZoom) / 100}
-          value={currentScale}
-          changeCallback={this.onSliderChange}
-        />
+        {createUserHubblePlot && (
+          <SliderVertical
+            className={hubblePlotZoom}
+            min={minZoom}
+            max={maxZoom}
+            step={(maxZoom - minZoom) / 100}
+            value={currentScale}
+            changeCallback={this.onSliderChange}
+          />
+        )}
         {loading && (
           <CircularProgress
             id={`${name}-loader`}
@@ -820,19 +822,21 @@ class HubblePlot extends React.Component {
               offsetTop,
             }}
           />
-          <Nudge
-            show={showNudge}
-            arrowDownCallback={this.nudgeSelection}
-            arrowUpCallback={this.resetNudge}
-            data={selectedData || hoveredData}
-            {...{
-              xScale,
-              yScale,
-              xValueAccessor,
-              yValueAccessor,
-              offsetTop,
-            }}
-          />
+          {createUserHubblePlot && (
+            <Nudge
+              show={showNudge}
+              arrowDownCallback={this.nudgeSelection}
+              arrowUpCallback={this.resetNudge}
+              data={selectedData || hoveredData}
+              {...{
+                xScale,
+                yScale,
+                xValueAccessor,
+                yValueAccessor,
+                offsetTop,
+              }}
+            />
+          )}
           <g>
             <g clipPath="url('#clip')">
               <CursorPoint

--- a/src/components/site/sliderVertical/index.jsx
+++ b/src/components/site/sliderVertical/index.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { verticalSlider } from './styles.module.scss';
+
+const SliderVertical = ({
+  min,
+  max,
+  step,
+  value,
+  disabled,
+  id,
+  className,
+  changeCallback,
+}) => {
+  return (
+    <input
+      className={classNames(verticalSlider, className)}
+      type="range"
+      onChange={changeCallback}
+      value={value}
+      {...{ min, max, step, disabled, id }}
+    />
+  );
+};
+
+SliderVertical.propTypes = {
+  id: PropTypes.string,
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  min: PropTypes.number,
+  max: PropTypes.number,
+  step: PropTypes.number,
+  changeCallback: PropTypes.func,
+  value: PropTypes.number,
+};
+
+export default SliderVertical;

--- a/src/components/site/sliderVertical/styles.module.scss
+++ b/src/components/site/sliderVertical/styles.module.scss
@@ -1,0 +1,35 @@
+$offset: 300px;
+
+.vertical-slider {
+  z-index: 2;
+  height: $minPadding;
+  cursor: pointer;
+  background: transparentize($white, 0.2);
+  border: 2px solid $black;
+  border-radius: 10px;
+  outline: none;
+  transform: rotate(-90deg);
+  appearance: none;
+
+  &:focus {
+    cursor: pointer;
+  }
+}
+
+.vertical-slider::-webkit-slider-thumb {
+  appearance: none;
+  width: $minPadding + 8px;
+  height: $minPadding + 8px;
+  background: $basePrimary;
+  border: 1px solid $black;
+  border-radius: 50%;
+}
+
+.vertical-slider::-moz-range-thumb {
+  appearance: none;
+  width: $minPadding + 8px;
+  height: $minPadding + 8px;
+  background: $basePrimary;
+  border: 1px solid $black;
+  border-radius: 50%;
+}

--- a/src/components/visualizations/orbitalViewer/PlaybackSpeed.jsx
+++ b/src/components/visualizations/orbitalViewer/PlaybackSpeed.jsx
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
 import { formatValue } from '../../../lib/utilities.js';
+import SliderVertical from '../../site/sliderVertical/index.jsx';
 import {
   playbackSpeedTitle,
   playbackSpeedSliderHeader,
@@ -112,14 +113,13 @@ function PlaybackSpeed({
       <div className={playbackSpeedSliderLabelBottom}>
         {t('orbit_viewer.playback.normal_time')}
       </div>
-      <input
+      <SliderVertical
         className={playbackSpeedSlider}
-        type="range"
         min={speeds.min}
         max={speeds.max}
         step={speeds.step}
         value={dayPerVizSec}
-        onChange={sliderOnChangeCallback}
+        changeCallback={sliderOnChangeCallback}
       />
       <div className={elapsedTimeContainer}>
         <div className={elapsedTimeTitle}>

--- a/src/components/visualizations/orbitalViewer/orbital-viewer.module.scss
+++ b/src/components/visualizations/orbitalViewer/orbital-viewer.module.scss
@@ -36,7 +36,8 @@ $offset: 300px;
   font-size: 12.5px;
 }
 
-.playback-speed-slider-label-bottom, .playback-speed-slider-label-top {
+.playback-speed-slider-label-bottom,
+.playback-speed-slider-label-top {
   @include labelSecondary;
   position: absolute;
   right: $minPadding / 2;
@@ -62,39 +63,8 @@ $offset: 300px;
   position: absolute;
   top: calc(80px + (#{$minPadding} + #{$tallestSquareWidget} - #{$offset}) / 2);
   right: $minPadding + 75px;
-  z-index: 2;
   width: calc(#{$tallestSquareWidget} - #{$offset});
-  height: $minPadding;
   margin-right: calc(-1 * (#{$tallestSquareWidget} - #{$offset}) / 2);
-  cursor: pointer;
-  background: transparentize($white, 0.2);
-  border: 2px solid $black;
-  border-radius: 10px;
-  outline: none;
-  transform: rotate(-90deg);
-  appearance: none;
-
-  &:focus {
-    cursor: pointer;
-  }
-}
-
-.playback-speed-slider::-webkit-slider-thumb {
-  appearance: none;
-  width: $minPadding + 8px;
-  height: $minPadding + 8px;
-  background: $basePrimary;
-  border: 1px solid $black;
-  border-radius: 50%;
-}
-
-.playback-speed-slider::-moz-range-thumb {
-  appearance: none;
-  width: $minPadding + 8px;
-  height: $minPadding + 8px;
-  background: $basePrimary;
-  border: 1px solid $black;
-  border-radius: 50%;
 }
 
 .elapsed-time-container {


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-7067

## What this change does ##

Moves the slider component in the orbit viewer into its own component and implements it to control zoom in the Hubble plotter

## Notes for reviewers ##

This change is two minor changes, porting a component and then implementing it. An additional check should be made on top of checking out the Hubble plotter to verify that the orbit viewer slider is still functioning.

Include an indication of how detailed a review you want on a 1-10 scale.
- 5

## Testing ##

Start Expanding Universe and go forward to the `/interpreting-a-hubble-plot-2` page, test the zoom both using the slider and mouse and combinations of the two. Start Surveying the Solar System and go to `/identifying-groups-1` and verify the slider on this page is still functioning as well.

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
