### PR TITLE
[C] randomize galaxy/supernova selector

### DIFF
--- a/src/data/pages/interpreting-hubble-plot-1.json
+++ b/src/data/pages/interpreting-hubble-plot-1.json
@@ -51,8 +51,8 @@
       "source": "/data/galaxies/galaxy_selector.json",
       "options": {
         "autoplay": true,
-        "preSelectedId": "ZTF19abqmpsr",
         "toggleDataPointsVisibility": "350",
+        "randomSource": true,
         "qaReview": false
       }
     }

--- a/src/data/pages/interpreting-hubble-plot-1_2.json
+++ b/src/data/pages/interpreting-hubble-plot-1_2.json
@@ -51,7 +51,7 @@
       "source": "/data/galaxies/galaxy_selector.json",
       "options": {
         "autoplay": true,
-        "preSelectedId": "ZTF20acuxpwz",
+        "randomSource": true,
         "toggleDataPointsVisibility": "351",
         "qaReview": false
       }

--- a/src/data/pages/interpreting-hubble-plot-1_3.json
+++ b/src/data/pages/interpreting-hubble-plot-1_3.json
@@ -51,7 +51,7 @@
       "source": "/data/galaxies/galaxy_selector.json",
       "options": {
         "autoplay": true,
-        "preSelectedId": "ZTF20acymtcs",
+        "randomSource": true,
         "toggleDataPointsVisibility": "352",
         "qaReview": false
       }

--- a/src/data/pages/interpreting-hubble-plot-1_4.json
+++ b/src/data/pages/interpreting-hubble-plot-1_4.json
@@ -51,7 +51,7 @@
       "source": "/data/galaxies/galaxy_selector.json",
       "options": {
         "autoplay": true,
-        "preSelectedId": "ZTF20acxzkkf",
+        "randomSource": true,
         "toggleDataPointsVisibility": "353",
         "qaReview": false
       }


### PR DESCRIPTION
For JIRA: "EPO-7152 #IN-REVIEW #comment randomize galaxy/supernova selector"

JIRA: https://jira.lsstcorp.org/browse/EPO-7152

## What this change does ##

Randomize the galaxy/supernova selector order

## Notes for reviewers ##

Check the deployment, change is localized to expanding universe with a few changes to page data and some new code in the galaxy/supernova selector component container

Include an indication of how detailed a review you want on a 1-10 scale.
- 4

## Testing ##

Clear answers for Expanding Universe, go forward to `interpreting-a-hubble-plot-1/` and verify a galaxy loads, then check the following 3 pages. Revisit each page to verify that the same galaxy loads each time. Clear answers and repeat the process, this time verifying that there has been some change in the order of the galaxy/supernova pairrings displayed.


## Checklist ##

If any of the following are true, please check them off
- [x] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [ ] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [x] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
