### PR TITLE
[C] get lang attribute from i18next

### DIFF
--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -9,13 +9,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { useStaticQuery, graphql } from 'gatsby';
+import { useTranslation } from 'react-i18next';
 import favicon from '../images/favicon/favicon.ico';
 import favicon16 from '../images/favicon/favicon-16x16.png';
 import favicon32 from '../images/favicon/favicon-32x32.png';
 import appleIcon from '../images/favicon/apple-touch-icon.png';
 import safariPinnedTab from '../images/favicon/safari-pinned-tab.svg';
 
-function SEO({ description, lang, meta, title }) {
+function SEO({ description, meta, title }) {
+  const { i18n } = useTranslation();
+  const { language: lang } = i18n;
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -85,7 +88,6 @@ function SEO({ description, lang, meta, title }) {
 }
 
 SEO.defaultProps = {
-  lang: `en`,
   meta: [],
   title: `Vera C. Rubin Observatory Educational Investigation`,
   description: `Rubin formal education investigation`,
@@ -93,7 +95,6 @@ SEO.defaultProps = {
 
 SEO.propTypes = {
   description: PropTypes.string,
-  lang: PropTypes.string,
   meta: PropTypes.arrayOf(PropTypes.object),
   title: PropTypes.string,
 };


### PR DESCRIPTION
For JIRA: "EPO-7676 #IN-REVIEW #comment get lang attribute from i18next"

JIRA: https://jira.lsstcorp.org/browse/EPO-7676

## What this change does ##

Set the html `lang` attribute using the currently set language from i18next

## Notes for reviewers ##

Verify on frontend that the `lang` attribute is set on the `html` element and updates when the language is changed

Include an indication of how detailed a review you want on a 1-10 scale.
- 1 = "I barely need review on this"

## Checklist ##

If any of the following are true, please check them off
- [ ] This is a breaking change: changes in page data (`/src/data/pages/PAGE.json`) or scientific data (anything in `/static/`) and I will notify Product Marketing when it is in prod and user visible.
- [x] This change impacts several investigations (e.g. the change affects reuseed styles, widgets, pages, QAs, utility methods, etc.)
- [ ] This change is isolated to a specific page or Component (i.e. it's a one-off)
- [ ] I don't know what this change does

## Screenshots (optional) ##
### Before:
### After:
